### PR TITLE
[Feat] 종목리스트 초기 UI구현

### DIFF
--- a/src/api/stockApi.ts
+++ b/src/api/stockApi.ts
@@ -5,17 +5,23 @@ import type { ApiResponse } from "./authApi";
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type StockItem = {
-  code: string;
-  name: string;
-  sector: string;
-  price: string;
-  change: string;
-  changeRate: string;
-  isPositive: boolean;
-  volume: string;
-  marketCap: string;
-  isHolding: boolean;
-  color: string;
+  tickerCode: string;
+  stockName: string;
+  stockLogo: string;
+  sectorType: string;
+  currentPrice: number;
+  changeRate: number;
+};
+
+export type StockItemMessage = {
+  data: {
+    tickerCode: string;
+    stockName: string;
+    stockLogo: string;
+    sectorType: string;
+    currentPrice: number;
+    changeRate: number;
+  };
 };
 
 // ─── Query Keys ───────────────────────────────────────────────────────────────
@@ -32,7 +38,19 @@ export function useStocksQuery() {
     queryFn: () =>
       fetchClient
         .get<ApiResponse<StockItem[]>>("/api/stocks")
-        .then((res) => res.data),
+        .then((res) => res.data.map((s) => ({ ...s, stockLogo: toLogoUrl(s.stockLogo) }))),
     staleTime: 30_000,
   });
+}
+
+const S3_BASE_URL = import.meta.env.VITE_S3_BASE_URL ?? "";
+
+function toLogoUrl(logo: string): string {
+  if (!logo || logo.startsWith("http")) return logo;
+  return `${S3_BASE_URL}/${logo}`;
+}
+
+export function parseStockItemMessage(msg: StockItemMessage): StockItem {
+  const { tickerCode, stockName, stockLogo, sectorType, currentPrice, changeRate } = msg.data;
+  return { tickerCode, stockName, stockLogo: toLogoUrl(stockLogo), sectorType, currentPrice, changeRate };
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -16,7 +16,6 @@ import Logo from "../ui/Logo";
 import { useAuthStore } from "@/store/authStore";
 import { authApi } from "@/api/authApi";
 
-
 export type NavItemConfig = {
   id: string;
   label: string;
@@ -43,7 +42,7 @@ const NAV_ITEMS: NavItemConfig[] = [
   { id: "home", label: "홈", icon: Home, href: "/" },
   { id: "invest", label: "모의투자", icon: BarChart2, href: "/invest" },
   { id: "account", label: "내 계좌", icon: Wallet, href: "/account" },
-  { id: "trade", label: "매매일지", icon: BookOpen, href: "/trade" },
+  { id: "trade", label: "매매일지", icon: BookOpen, href: "/trade-diary" },
   { id: "users", label: "유저 목록", icon: Users, href: "/users" },
   { id: "alarm", label: "알림", icon: Bell, href: "/alarm", badge: 3 },
   { id: "mentor", label: "나의 멘토", icon: GraduationCap, href: "/mentor" },

--- a/src/lib/fetchClient.ts
+++ b/src/lib/fetchClient.ts
@@ -13,6 +13,7 @@ function buildUrl(path: string, params?: Record<string, string>): string {
 async function request<T>(
   path: string,
   options: RequestInit & { params?: Record<string, string> } = {},
+  _retry = true,
 ): Promise<T> {
   const { params, headers, ...init } = options;
   const token = useAuthStore.getState().accessToken;
@@ -26,6 +27,26 @@ async function request<T>(
       ...headers,
     },
   });
+
+  // 401/403: 토큰 재발급 후 1회 재시도
+  if ((res.status === 401 || res.status === 403) && _retry) {
+    try {
+      const reissueRes = await fetch(buildUrl("/api/auth/reissue"), {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+      });
+      if (!reissueRes.ok) throw new Error();
+      const { data } = await reissueRes.json();
+      if (!data?.accessToken) throw new Error();
+      useAuthStore.getState().setAccessToken(data.accessToken);
+      return request<T>(path, options, false);
+    } catch {
+      useAuthStore.getState().clearAuth();
+      window.location.href = "/login";
+      throw new Error("Unauthorized");
+    }
+  }
 
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json() as Promise<T>;

--- a/src/pages/TradeDiaryPage.tsx
+++ b/src/pages/TradeDiaryPage.tsx
@@ -1,0 +1,34 @@
+import { Search } from "lucide-react";
+import { useState } from "react";
+
+export default function TradeDiaryPage() {
+  const [search, setSearch] = useState("");
+
+  return (
+    <div className="flex flex-col h-full p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
+      {/* 헤더 */}
+      <div>
+        <h1 className="text-[22px] font-bold text-gray-900">매매일지</h1>
+      </div>
+      {/* 검색 + 정렬 */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1 max-w-xs">
+          <Search
+            size={15}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+          />
+          <input
+            type="text"
+            placeholder="종목명 또는 코드 검색"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-9 pr-4 py-2 text-[13px] bg-white border border-gray-200 rounded-xl outline-none focus:border-[#0046FF] transition-colors"
+          />
+        </div>
+      </div>
+
+      {/* 매매일지 리스트 */}
+      <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden"></div>
+    </div>
+  );
+}

--- a/src/pages/stocks/StockList.tsx
+++ b/src/pages/stocks/StockList.tsx
@@ -1,37 +1,57 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Search, TrendingUp, TrendingDown } from "lucide-react";
 import Avatar from "@/components/ui/Avatar";
-import { useMarketIndicesQuery } from "@/api/homeApi";
-import type { MarketIndexData } from "@/api/homeApi";
-import type { StockItem } from "@/api/stockApi";
+
+import {
+  useMarketIndicesQuery,
+  parseMarketIndicatorMessage,
+  homeQueryKeys,
+} from "@/api/homeApi";
+import {
+  useStocksQuery,
+  stockQueryKeys,
+  parseStockItemMessage,
+} from "@/api/stockApi";
+import type { MarketIndexData, MarketIndicatorMessage } from "@/api/homeApi";
+import type { StockItem, StockItemMessage } from "@/api/stockApi";
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+import { useQueryClient } from "@tanstack/react-query";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const SECTORS = [
-  "전체", "반도체", "2차전지", "바이오", "자동차",
-  "IT", "금융", "철강", "화학", "통신", "가변", "건설",
-];
+const SECTOR_MAP: Record<string, string> = {
+  INFORMATION_TECHNOLOGY: "반도체",
+  SECONDARY_BATTERY: "2차전지",
+  HEALTHCARE: "바이오",
+  AUTOMOBILE: "자동차",
+  IT: "IT",
+  FINANCIALS: "금융",
+  STEEL_MATERIALS: "철강",
+  ENERGY_CHEMICALS: "화학",
+  TELECOM: "통신",
+  UTILITIES: "가변",
+  CONSTRUCTION: "건설",
+  CONSUMER_STAPLES: "소비재",
+  INDUSTRIALS: "산업재",
+  HEAVY_INDUSTRIES: "중공업",
+  COMMUNICATION_SERVICES: "통신",
+};
+
+const SECTORS = ["전체", ...new Set(Object.values(SECTOR_MAP))];
 
 const SORTS = ["거래량순", "상승순", "하락순", "고가순"] as const;
 type SortType = (typeof SORTS)[number];
 
-// ─── Mock 데이터 (백엔드 API 완성 후 교체) ──────────────────────────────────
-
-const MOCK_STOCKS: StockItem[] = [
-  { code: "005930", name: "삼성전자",   sector: "반도체",  price: "73,400원",  change: "+900",   changeRate: "+1.24%", isPositive: true,  volume: "1284만", marketCap: "4382000억원", isHolding: true,  color: "#F59E0B" },
-  { code: "000660", name: "SK하이닉스", sector: "반도체",  price: "192,500원", change: "+4,500", changeRate: "+2.39%", isPositive: true,  volume: "324만",  marketCap: "139800억원",  isHolding: false, color: "#10B981" },
-  { code: "035720", name: "카카오",     sector: "IT",      price: "44,850원",  change: "-550",   changeRate: "-1.21%", isPositive: false, volume: "234만",  marketCap: "19500억원",   isHolding: false, color: "#F59E0B" },
-  { code: "247540", name: "에코프로비엠", sector: "2차전지", price: "148,500원", change: "-4,900", changeRate: "-3.19%", isPositive: false, volume: "123만",  marketCap: "13200억원",   isHolding: false, color: "#6366F1" },
-  { code: "068270", name: "셀트리온",   sector: "바이오",  price: "178,500원", change: "+4,000", changeRate: "+2.28%", isPositive: true,  volume: "98만",   marketCap: "24300억원",   isHolding: false, color: "#8B5CF6" },
-  { code: "000270", name: "기아",       sector: "자동차",  price: "108,500원", change: "+2,200", changeRate: "+2.07%", isPositive: true,  volume: "124만",  marketCap: "43800억원",   isHolding: false, color: "#F97316" },
-  { code: "005380", name: "현대차",     sector: "자동차",  price: "241,500원", change: "+4,000", changeRate: "+1.68%", isPositive: true,  volume: "84만",   marketCap: "51500억원",   isHolding: false, color: "#3B82F6" },
-  { code: "105560", name: "KB금융",     sector: "금융",    price: "87,200원",  change: "+800",   changeRate: "+0.92%", isPositive: true,  volume: "72만",   marketCap: "34800억원",   isHolding: false, color: "#14B8A6" },
-  { code: "035420", name: "NAVER",      sector: "IT",      price: "192,000원", change: "+1,500", changeRate: "+0.79%", isPositive: true,  volume: "67만",   marketCap: "31500억원",   isHolding: false, color: "#22C55E" },
-];
-
 // ─── 시장 지수 패널 ────────────────────────────────────────────────────────────
 
-function MarketPanel({ data, loading }: { data: MarketIndexData[]; loading: boolean }) {
+function MarketPanel({
+  data,
+  loading,
+}: {
+  data: MarketIndexData[];
+  loading: boolean;
+}) {
   if (loading) {
     return (
       <div className="bg-white rounded-2xl border border-gray-100 flex divide-x divide-gray-100 animate-pulse">
@@ -51,14 +71,22 @@ function MarketPanel({ data, loading }: { data: MarketIndexData[]; loading: bool
     <div className="bg-white rounded-2xl border border-gray-100 flex divide-x divide-gray-100">
       {data.map((idx) => (
         <div key={idx.label} className="flex-1 px-6 py-5">
-          <p className="text-[13px] text-gray-400 font-medium mb-1">{idx.label}</p>
+          <p className="text-[13px] text-gray-400 font-medium mb-1">
+            {idx.label}
+          </p>
           <p className="text-[24px] font-bold text-gray-900">{idx.value}</p>
           <div className="flex items-center gap-1 mt-0.5">
-            {idx.isPositive
-              ? <TrendingUp size={12} className="text-red-500" />
-              : <TrendingDown size={12} className="text-blue-600" />}
-            <span className={`text-[12px] font-medium ${idx.isPositive ? "text-red-500" : "text-blue-600"}`}>
-              {idx.isPositive ? "▲" : "▼"}{idx.change} ({idx.isPositive ? "+" : "-"}{idx.changePercent}%)
+            {idx.isPositive ? (
+              <TrendingUp size={12} className="text-red-500" />
+            ) : (
+              <TrendingDown size={12} className="text-blue-600" />
+            )}
+            <span
+              className={`text-[12px] font-medium ${idx.isPositive ? "text-red-500" : "text-blue-600"}`}
+            >
+              {idx.isPositive ? "▲" : "▼"}
+              {idx.change} ({idx.isPositive ? "+" : "-"}
+              {idx.changePercent}%)
             </span>
           </div>
           <p className="text-[12px] text-gray-400 mt-1">
@@ -77,37 +105,31 @@ function StockRow({ stock }: { stock: StockItem }) {
     <tr className="hover:bg-gray-50/50 transition-colors">
       <td className="px-5 py-3.5">
         <div className="flex items-center gap-3">
-          <Avatar name={stock.name} color={stock.color} size={34} />
+          <Avatar name={stock.stockName} src={stock.stockLogo} size={34} />
           <div>
             <div className="flex items-center gap-1.5">
-              <span className="text-[14px] font-semibold text-gray-900">{stock.name}</span>
-              {stock.isHolding && (
-                <span className="text-[10px] font-medium text-[#0046FF] bg-blue-50 px-1.5 py-0.5 rounded">
-                  보유
-                </span>
-              )}
+              <span className="text-[14px] font-semibold text-gray-900">
+                {stock.stockName}
+              </span>
             </div>
-            <p className="text-[11px] text-gray-400 mt-0.5">{stock.code}</p>
+            <p className="text-[11px] text-gray-400 mt-0.5">
+              {stock.tickerCode}
+            </p>
           </div>
         </div>
       </td>
-      <td className="px-4 py-3.5 text-[13px] text-gray-500">{stock.sector}</td>
-      <td className="px-4 py-3.5 text-right text-[14px] font-semibold text-gray-900">{stock.price}</td>
+      <td className="px-4 py-3.5 text-[13px] text-gray-500">
+        {SECTOR_MAP[stock.sectorType] ?? stock.sectorType}
+      </td>
+      <td className="px-4 py-3.5 text-right text-[14px] font-semibold text-gray-900">
+        {stock.currentPrice.toLocaleString()}
+      </td>
       <td className="px-4 py-3.5 text-right">
-        <span className={`text-[13px] font-semibold ${stock.isPositive ? "text-red-500" : "text-blue-600"}`}>
+        <span
+          className={`text-[13px] font-semibold ${stock.changeRate > 0 ? "text-red-500" : stock.changeRate < 0 ? "text-blue-500" : "text-gray-500"}`}
+        >
           {stock.changeRate}
         </span>
-        <br />
-        <span className={`text-[11px] ${stock.isPositive ? "text-red-400" : "text-blue-400"}`}>
-          {stock.change}
-        </span>
-      </td>
-      <td className="px-4 py-3.5 text-right text-[13px] text-gray-600">{stock.volume}</td>
-      <td className="px-4 py-3.5 text-right text-[13px] text-gray-600">{stock.marketCap}</td>
-      <td className="px-5 py-3.5 text-right">
-        <button className="bg-[#0046FF] text-white text-[12px] font-medium px-3 py-1.5 rounded-lg hover:bg-blue-700 transition-colors whitespace-nowrap">
-          거래 &gt;
-        </button>
       </td>
     </tr>
   );
@@ -116,20 +138,73 @@ function StockRow({ stock }: { stock: StockItem }) {
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function StockList() {
-  const { data: marketIndices = [], isLoading: loadingMarket } = useMarketIndicesQuery();
-  const [stocks] = useState<StockItem[]>(MOCK_STOCKS);
-  // TODO: 백엔드 API 완성 후 교체
-  // const { data: stocks = [] } = useStocksQuery();
+  const queryClient = useQueryClient();
+  const { data: marketIndices = [], isLoading: loadingMarket } =
+    useMarketIndicesQuery();
+  const { data: stocks = [] } = useStocksQuery();
+
   const [search, setSearch] = useState("");
   const [sector, setSector] = useState("전체");
   const [sort, setSort] = useState<SortType>("거래량순");
 
+  // ── STOMP 실시간 업데이트 → React Query 캐시 갱신 ───────────────────────
+  useEffect(() => {
+    const wsUrl = (import.meta.env.VITE_API_BASE_URL ?? "") + "/ws";
+    const client = new Client({
+      webSocketFactory: () => new SockJS(wsUrl),
+      onConnect: () => {
+        console.log("[STOMP] 연결됨");
+        client.subscribe("/topic/market/indicators", (message) => {
+          const msg: MarketIndicatorMessage = JSON.parse(message.body);
+          console.log("[STOMP] 지수 메시지 수신:", msg.data);
+          const updated = parseMarketIndicatorMessage(msg);
+          queryClient.setQueryData<MarketIndexData[]>(
+            homeQueryKeys.marketIndices,
+            (prev = []) =>
+              prev.map((item) =>
+                item.label === updated.label ? updated : item,
+              ),
+          );
+        });
+
+        stocks.forEach(({ tickerCode }) => {
+          client.subscribe(`/topic/stocks/${tickerCode}/quote`, (message) => {
+            const msg: StockItemMessage = JSON.parse(message.body);
+            console.log("[STOMP] 종목리스트 메시지 수신:", msg.data);
+            const updated = parseStockItemMessage(msg);
+            queryClient.setQueryData<StockItem[]>(
+              stockQueryKeys.stocks,
+              (prev = []) =>
+                prev.map((item) =>
+                  item.tickerCode === updated.tickerCode ? updated : item,
+                ),
+            );
+          });
+        });
+      },
+      onDisconnect: () => console.log("[STOMP] 연결 끊김"),
+      onStompError: (frame) => console.error("[STOMP] 에러:", frame),
+    });
+    client.activate();
+    return () => {
+      client.deactivate();
+    };
+  }, [queryClient, stocks]);
+
   const filtered = stocks
-    .filter((s) => sector === "전체" || s.sector === sector)
-    .filter((s) =>
-      s.name.toLowerCase().includes(search.toLowerCase()) ||
-      s.code.includes(search)
-    );
+    .filter((s) => sector === "전체" || SECTOR_MAP[s.sectorType] === sector)
+    .filter(
+      (s) =>
+        s.stockName.toLowerCase().includes(search.toLowerCase()) ||
+        s.tickerCode.includes(search),
+    )
+    .slice()
+    .sort((a, b) => {
+      if (sort === "상승순") return b.changeRate - a.changeRate;
+      if (sort === "하락순") return a.changeRate - b.changeRate;
+      if (sort === "고가순") return b.currentPrice - a.currentPrice;
+      return 0; // 거래량순: 서버 기본 순서 유지
+    });
 
   return (
     <div className="flex flex-col h-full p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
@@ -147,7 +222,10 @@ export default function StockList() {
       {/* 검색 + 정렬 */}
       <div className="flex items-center gap-3">
         <div className="relative flex-1 max-w-xs">
-          <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <Search
+            size={15}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+          />
           <input
             type="text"
             placeholder="종목명 또는 코드 검색"
@@ -195,21 +273,31 @@ export default function StockList() {
         <table className="w-full">
           <thead>
             <tr className="bg-gray-50 border-b border-gray-100">
-              <th className="text-left px-5 py-3 text-[12px] text-gray-400 font-medium">종목명</th>
-              <th className="text-left px-4 py-3 text-[12px] text-gray-400 font-medium">섹터</th>
-              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">현재가</th>
-              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">등락률</th>
-              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">거래량</th>
-              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">시가총액</th>
-              <th className="px-5 py-3" />
+              <th className="text-left px-5 py-3 text-[12px] text-gray-400 font-medium">
+                종목명
+              </th>
+              <th className="text-left px-4 py-3 text-[12px] text-gray-400 font-medium">
+                섹터
+              </th>
+              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">
+                현재가
+              </th>
+              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">
+                등락률
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50">
             {filtered.length > 0 ? (
-              filtered.map((stock) => <StockRow key={stock.code} stock={stock} />)
+              filtered.map((stock) => (
+                <StockRow key={stock.tickerCode} stock={stock} />
+              ))
             ) : (
               <tr>
-                <td colSpan={7} className="text-center py-12 text-[14px] text-gray-400">
+                <td
+                  colSpan={4}
+                  className="text-center py-12 text-[14px] text-gray-400"
+                >
                   검색 결과가 없습니다.
                 </td>
               </tr>

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -7,6 +7,7 @@ import SignUpPage from "@/pages/auth/SignUpPage";
 import OAuthCallbackPage from "@/pages/auth/OauthCallbackPage";
 import StockList from "@/pages/stocks/StockList";
 import ProtectedRoute from "./ProtectedRoute";
+import TradeDiaryPage from "@/pages/TradeDiaryPage";
 
 export const router = createBrowserRouter([
   {
@@ -19,15 +20,7 @@ export const router = createBrowserRouter([
           { index: true, element: <HomePage /> },
           { path: "invest", element: <StockList /> },
           { path: "components", element: <ComponentsPage /> },
-          // { index: true, element: <HomePage /> },
-          // { path: "invest", element: <InvestPage /> },
-          // { path: "account", element: <AccountPage /> },
-          // { path: "trade", element: <TradePage /> },
-          // { path: "users", element: <UsersPage /> },
-          // { path: "alarm", element: <AlarmPage /> },
-          // { path: "mentor", element: <MentorPage /> },
-          // { path: "mentee", element: <MenteePage /> },
-          // { path: "profile", element: <ProfilePage /> },
+          { path: "trade-diary", element: <TradeDiaryPage /> },
         ],
       },
     ],

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -2,29 +2,19 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
-// POST /api/v1/auth/login Response의 data 필드 기준
-// refreshToken은 body에 있지만 httpOnly 쿠키로 관리 → 프론트에서 무시
 export interface AuthUser {
   nickname: string;
 }
 
 interface AuthState {
-  accessToken: string | null;  // sessionStorage에 persist
-  user: AuthUser | null;       // sessionStorage에 persist
-  isLoggedIn: boolean;         // sessionStorage에 persist
+  accessToken: string | null; // sessionStorage에 persist
+  user: AuthUser | null;      // sessionStorage에 persist
+  // isLoggedIn 제거 → accessToken !== null 으로 파생
 }
 
 interface AuthActions {
-  // 로그인 성공 후 호출 (email / google 공통)
-  // refreshToken은 httpOnly 쿠키로 서버가 관리하므로 인자에서 제외
   setAuth: (accessToken: string, user: AuthUser) => void;
-
-  // accessToken 갱신 — POST /api/v1/auth/reissue 성공 후 호출
-  // reissue 요청 시 refreshToken은 쿠키에서 자동 포함 (withCredentials: true)
   setAccessToken: (accessToken: string) => void;
-
-  // 로그아웃 — POST /api/v1/auth/logout 성공 후 호출
-  // 서버가 Set-Cookie: Max-Age=0 으로 refreshToken 쿠키 삭제
   clearAuth: () => void;
 }
 
@@ -35,26 +25,20 @@ export const useAuthStore = create<AuthState & AuthActions>()(
       // ── 초기값
       accessToken: null,
       user: null,
-      isLoggedIn: false,
 
       // ── Actions
-      setAuth: (accessToken, user) =>
-        set({ accessToken, user, isLoggedIn: true }),
+      setAuth: (accessToken, user) => set({ accessToken, user }),
 
-      setAccessToken: (accessToken) =>
-        set({ accessToken }),
+      setAccessToken: (accessToken) => set({ accessToken }),
 
-      clearAuth: () =>
-        set({ accessToken: null, user: null, isLoggedIn: false }),
+      clearAuth: () => set({ accessToken: null, user: null }),
     }),
     {
       name: "solmate-auth",
-      storage: createJSONStorage(() => sessionStorage), // 탭 닫으면 자동 삭제
-      // accessToken도 sessionStorage에 저장 — 새로고침 시 reissue로 갱신
+      storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         accessToken: state.accessToken,
         user: state.user,
-        isLoggedIn: state.isLoggedIn,
       }),
     }
   )
@@ -62,5 +46,5 @@ export const useAuthStore = create<AuthState & AuthActions>()(
 
 // ─── Selectors ────────────────────────────────────────────────────────────────
 export const useUser = () => useAuthStore((s) => s.user);
-export const useIsLoggedIn = () => useAuthStore((s) => s.isLoggedIn);
+export const useIsLoggedIn = () => useAuthStore((s) => s.accessToken !== null);
 export const useAccessToken = () => useAuthStore((s) => s.accessToken);


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #14 

## 💡 작업 배경
종목리스트 UI 기본 세팅 및 API 연동 확인

## 🧩 작업 내용
모의투자 탭 내 Kospi200 종목 리스트, 기업 사진, 섹터, 실시간 시세, 상승률 연동

## 📸 스크린샷(선택)


## 📝 기타
섹터 매핑 확인, 거래량 및 시가총액 추가 필요