### PR TITLE
[Feat] 매매일지 상세페이지 구현

### DIFF
--- a/src/api/tradeDiaryApi.ts
+++ b/src/api/tradeDiaryApi.ts
@@ -1,5 +1,5 @@
 import { fetchClient } from "@/lib/fetchClient";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiResponse } from "./authApi";
 
 export type MyDiariesItem = {
@@ -14,15 +14,37 @@ export type MyDiariesItem = {
   createdAt: string;
 };
 
+export type DiaryComment = {
+  commentId: number;
+  nickname: string;
+  isMentor: boolean;
+  content: string;
+};
+
+export type DiaryDetail = {
+  diaryId: number;
+  tradeType: string;
+  stockName: string;
+  tickerCode: string;
+  filledPrice: number;
+  quantity: number;
+  profit: number;
+  profitRate: number;
+  content: string;
+  createdAt: string;
+  comments: DiaryComment[];
+};
+
 export const myDiariesQueryKeys = {
-  stocks: ["my-diaries"] as const,
+  myDiaries: ["my-diaries"] as const,
+  diaryDetail: (diaryId: string) => ["diary-detail", diaryId] as const,
 };
 
 // ─── React Query Hooks ────────────────────────────────────────────────────────
 
 export function useMyDiariesQuery() {
   return useQuery({
-    queryKey: myDiariesQueryKeys.stocks,
+    queryKey: myDiariesQueryKeys.myDiaries,
     queryFn: () =>
       fetchClient
         .get<ApiResponse<MyDiariesItem[]>>("/api/diaries/my")
@@ -30,5 +52,30 @@ export function useMyDiariesQuery() {
           return res.data;
         }),
     staleTime: 30_000,
+  });
+}
+
+export function useDiaryDetailQuery(diaryId: string) {
+  return useQuery({
+    queryKey: myDiariesQueryKeys.diaryDetail(diaryId),
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<DiaryDetail>>(`/api/diaries/${diaryId}`)
+        .then((res) => res.data),
+    staleTime: 30_000,
+    enabled: !!diaryId,
+  });
+}
+
+export function usePostCommentMutation(diaryId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (content: string) =>
+      fetchClient.post(`/api/diaries/${diaryId}/comments`, { content }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: myDiariesQueryKeys.diaryDetail(diaryId),
+      });
+    },
   });
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -167,7 +167,9 @@ export default function SidebarNav() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const activeId =
-    NAV_ITEMS.find((item) => item.href === pathname)?.id ?? "home";
+    NAV_ITEMS.find((item) => item.href !== "/" && pathname.startsWith(item.href))?.id ??
+    (pathname === "/" ? "home" : undefined) ??
+    "home";
 
   const storeUser = useAuthStore((s) => s.user);
   const clearAuth = useAuthStore((s) => s.clearAuth);

--- a/src/lib/fetchClient.ts
+++ b/src/lib/fetchClient.ts
@@ -5,7 +5,8 @@ const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
 function buildUrl(path: string, params?: Record<string, string>): string {
   const base = BASE_URL || window.location.origin;
   const url = new URL(path, base);
-  if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  if (params)
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
   // BASE_URL 없으면 Vite 프록시를 통해 요청 (상대 경로)
   return BASE_URL ? url.toString() : url.pathname + url.search;
 }
@@ -59,6 +60,12 @@ export const fetchClient = {
   post: <T>(path: string, body?: unknown) =>
     request<T>(path, {
       method: "POST",
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    }),
+
+  delete: <T>(path: string, body?: unknown) =>
+    request<T>(path, {
+      method: "DELETE",
       body: body !== undefined ? JSON.stringify(body) : undefined,
     }),
 };

--- a/src/pages/trade-diaries/TradeDiaryPage.tsx
+++ b/src/pages/trade-diaries/TradeDiaryPage.tsx
@@ -1,16 +1,26 @@
 import { useMyDiariesQuery } from "@/api/tradeDiaryApi";
 import { Search } from "lucide-react";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import type { MyDiariesItem } from "@/api/tradeDiaryApi";
 import Badge from "@/components/ui/Badge";
 
-function MyDiariesRow({ myDiaries }: { myDiaries: MyDiariesItem }) {
+function MyDiariesRow({
+  myDiaries,
+  onClick,
+}: {
+  myDiaries: MyDiariesItem;
+  onClick: () => void;
+}) {
   const isBuy = myDiaries.tradeType === "BUY";
   const hasProfit = myDiaries.profit !== 0;
   const isPositive = myDiaries.profit > 0;
 
   return (
-    <div className="flex flex-col gap-2 px-6 py-5 border-b border-gray-100 last:border-b-0">
+    <div
+      onClick={onClick}
+      className="flex flex-col gap-2 px-6 py-5 border-b border-gray-100 last:border-b-0 cursor-pointer hover:bg-gray-50"
+    >
       {/* 상단: 뱃지 + 종목명 + 수량/가격/날짜 + 수익 */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -36,7 +46,7 @@ function MyDiariesRow({ myDiaries }: { myDiaries: MyDiariesItem }) {
         {hasProfit && (
           <span
             className={`text-[14px] font-semibold ${
-              isPositive ? "text-[#0046FF]" : "text-[#FF4444]"
+              isPositive ? "text-[#FF4444]" : "text-[#0046FF]"
             }`}
           >
             {isPositive ? "+" : ""}
@@ -73,6 +83,7 @@ function MyDiariesRow({ myDiaries }: { myDiaries: MyDiariesItem }) {
 }
 
 export default function TradeDiaryPage() {
+  const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const { data: myDiaries = [] } = useMyDiariesQuery();
 
@@ -107,7 +118,11 @@ export default function TradeDiaryPage() {
       <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
         {filtered.length > 0 ? (
           filtered.map((item) => (
-            <MyDiariesRow key={item.diaryId} myDiaries={item} />
+            <MyDiariesRow
+              key={item.diaryId}
+              myDiaries={item}
+              onClick={() => navigate(`/trade-diary/${item.diaryId}`)}
+            />
           ))
         ) : (
           <div className="text-center py-12 text-[14px] text-gray-400">

--- a/src/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPage.tsx
+++ b/src/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPage.tsx
@@ -1,3 +1,229 @@
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { ChevronLeft, Pencil } from "lucide-react";
+import { useDiaryDetailQuery, usePostCommentMutation } from "@/api/tradeDiaryApi";
+import Button from "@/components/ui/Button";
+import { useUser } from "@/store/authStore";
+
+function formatProfit(profit: number) {
+  const manwon = profit / 10000;
+  const sign = manwon >= 0 ? "+" : "";
+  return `${sign}${manwon % 1 === 0 ? manwon : manwon.toFixed(1)}만원`;
+}
+
+function formatProfitRate(rate: number) {
+  const sign = rate >= 0 ? "+" : "";
+  return `${sign}${rate.toFixed(2)}%`;
+}
+
+function formatDate(createdAt: string) {
+  const date = new Date(createdAt);
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+}
+
+function formatPrice(price: number) {
+  return price.toLocaleString("ko-KR") + "원";
+}
+
+function formatTotal(price: number, quantity: number) {
+  const total = price * quantity;
+  const manwon = total / 10000;
+  return `${manwon % 1 === 0 ? manwon : manwon.toFixed(1)}만원`;
+}
+
 export default function DiaryDetailPage() {
-  return <div>DiaryDetailPage</div>;
+  const navigate = useNavigate();
+  const { tradeDiaryId } = useParams<{ tradeDiaryId: string }>();
+  const {
+    data: diary,
+    isLoading,
+    isError,
+  } = useDiaryDetailQuery(tradeDiaryId ?? "");
+  const [commentInput, setCommentInput] = useState("");
+  const user = useUser();
+  const { mutate: postComment, isPending } = usePostCommentMutation(tradeDiaryId ?? "");
+
+  const isProfit = (diary?.profit ?? 0) >= 0;
+  const profitColor = isProfit ? "text-[#FF4444]" : "text-[#0046FF]";
+  const tradeTypeLabel = diary?.tradeType === "BUY" ? "매수" : "매도";
+  const tradeTypeBg =
+    diary?.tradeType === "BUY" ? "bg-[#FF4444]" : "bg-[#0046FF]";
+
+  return (
+    <div className="flex flex-col h-full p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => navigate("/trade-diary")}
+            className="text-gray-500 hover:text-gray-800 cursor-pointer"
+          >
+            <ChevronLeft size={20}/>
+          </button>
+          <span className="text-gray-400 text-[14px]">매매일지</span>
+          <span className="text-gray-300 text-[14px]">›</span>
+          <span className="text-[14px] font-semibold text-gray-900">
+            매매일지 상세
+          </span>
+        </div>
+        <button className="text-gray-400 hover:text-gray-700">
+          <Pencil size={16} />
+        </button>
+      </div>
+
+      {/* 메인 카드 */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-5 flex flex-col gap-4">
+        {isLoading && (
+          <p className="text-[14px] text-gray-400 text-center py-8">
+            불러오는 중...
+          </p>
+        )}
+        {isError && (
+          <p className="text-[14px] text-red-400 text-center py-8">
+            데이터를 불러오지 못했습니다.
+          </p>
+        )}
+        {diary && (
+          <>
+            {/* 종목 정보 */}
+            <div className="flex items-start justify-between">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`px-2 py-0.5 text-[12px] font-semibold text-white ${tradeTypeBg} rounded`}
+                >
+                  {tradeTypeLabel}
+                </span>
+                <span className="text-[18px] font-bold text-gray-900">
+                  {diary.stockName}
+                </span>
+                <span className="text-[12px] text-gray-400">
+                  {diary.tickerCode}
+                </span>
+              </div>
+              <div className="text-right">
+                <p className={`text-[16px] font-bold ${profitColor}`}>
+                  {formatProfit(diary.profit)}
+                </p>
+              </div>
+            </div>
+
+            {/* 체결 요약 */}
+            <p className="text-[13px] text-gray-400">
+              {diary.quantity}주 · {formatPrice(diary.filledPrice)} ·{" "}
+              {formatDate(diary.createdAt)}
+            </p>
+
+            {/* 체결 상세 */}
+            <div className="grid grid-cols-3 divide-x divide-gray-100 border border-gray-100 rounded-xl overflow-hidden">
+              {[
+                { label: "체결수량", value: `${diary.quantity}주` },
+                {
+                  label: "체결가격",
+                  value: diary.filledPrice ? formatPrice(diary.filledPrice) : 0,
+                },
+                {
+                  label: "총 체결금액",
+                  value: formatTotal(diary.filledPrice, diary.quantity),
+                },
+              ].map(({ label, value }) => (
+                <div
+                  key={label}
+                  className="flex flex-col items-center py-3 gap-1"
+                >
+                  <span className="text-[12px] text-gray-400">{label}</span>
+                  <span className="text-[14px] font-semibold text-gray-900">
+                    {value}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {/* 매매 일지 */}
+            <div>
+              <p className="text-[14px] text-gray-400 mb-1">매매 일지</p>
+              <p className="text-[16px] text-gray-700 leading-relaxed">
+                {diary.content}
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* 댓글 */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-5 flex flex-col gap-4">
+        <p className="text-[14px] font-semibold text-gray-900">
+          댓글 ({diary?.comments?.length ?? 0})
+        </p>
+
+        {/* 댓글 목록 */}
+        <div className="flex flex-col gap-3">
+          {diary?.comments?.map((comment) => (
+            <div key={comment.commentId} className="flex gap-3">
+              <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center text-gray-600 text-[12px] font-bold shrink-0">
+                {comment.nickname.charAt(0)}
+              </div>
+              <div className="flex flex-col gap-0.5 flex-1">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[13px] font-semibold text-gray-900">
+                      {comment.nickname}
+                    </span>
+                    {comment.isMentor && (
+                      <span className="px-1.5 py-0.5 text-[10px] font-semibold text-white bg-[#0046FF] rounded">
+                        멘토
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button variant="basic" className="text-[11px] px-2 py-0.5">
+                      수정
+                    </Button>
+                    {user?.nickname === comment.nickname ? (
+                      <Button
+                        variant="basic"
+                        className="text-[11px] px-2 py-0.5 border-red-500! text-red-500! hover:bg-red-50!"
+                      >
+                        삭제
+                      </Button>
+                    ) : (
+                      <Button variant="invalid" className="text-[11px] px-2 py-0.5">
+                        삭제
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                <p className="text-[13px] text-gray-700 leading-relaxed">
+                  {comment.content}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* 댓글 입력 */}
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-full bg-[#0046FF] flex items-center justify-center text-white text-[12px] font-bold shrink-0">
+            투
+          </div>
+          <input
+            type="text"
+            value={commentInput}
+            onChange={(e) => setCommentInput(e.target.value)}
+            placeholder="댓글을 입력하세요..."
+            className="flex-1 px-4 py-2 text-[14px] bg-gray-50 border border-gray-200 rounded-xl outline-none focus:border-[#0046FF] transition-colors"
+          />
+          <button
+            disabled={isPending}
+            onClick={() => {
+              if (!commentInput.trim()) return;
+              postComment(commentInput, { onSuccess: () => setCommentInput("") });
+            }}
+            className="px-4 py-2 text-[14px] font-semibold text-white bg-[#0046FF] rounded-xl hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            등록
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -8,6 +8,7 @@ import OAuthCallbackPage from "@/pages/auth/OauthCallbackPage";
 import StockList from "@/pages/stocks/StockList";
 import ProtectedRoute from "./ProtectedRoute";
 import TradeDiaryPage from "@/pages/trade-diaries/TradeDiaryPage";
+import DiaryDetailPage from "@/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPage";
 
 export const router = createBrowserRouter([
   {
@@ -20,7 +21,13 @@ export const router = createBrowserRouter([
           { index: true, element: <HomePage /> },
           { path: "invest", element: <StockList /> },
           { path: "components", element: <ComponentsPage /> },
-          { path: "trade-diary", element: <TradeDiaryPage /> },
+          {
+            path: "trade-diary",
+            children: [
+              { index: true, element: <TradeDiaryPage /> },
+              { path: ":tradeDiaryId", element: <DiaryDetailPage /> },
+            ],
+          },
         ],
       },
     ],


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #18 

## 💡 작업 배경
매매 내역 목록 조회부터 개별 일지 상세 확인, 댓글을 통한 멘토와의 소통까지 이어지는 플로우를 구현하기 위해 작업을 진행

## 🧩 작업 내용
매매일지 리스트 페이지 (TradeDiaryPage)
- 내 매매일지 목록을 카드 형태로 렌더링
- 종목명 기반 실시간 검색 필터 구현
- 매수/매도 뱃지, 종목명, 수량, 체결가, 날짜, 수익, 댓글 수 표시
- 수익 양수 시 빨간색(#FF4444), 음수 시 파란색(#0046FF) 색상 구분
- 항목 클릭 시 상세 페이지로 이동

매매일지 상세 페이지 (DiaryDetailPage)
- URL 파라미터(tradeDiaryId) 기반 개별 일지 데이터 조회
- 종목 정보, 체결 요약(수량·가격·날짜), 체결 상세(체결수량/체결가격/총 체결금액) 표시
- 수익/손실 만원 단위 포맷(+N만원) 및 색상 처리
- 댓글 목록 렌더링 - 멘토 여부 뱃지, 본인 댓글 삭제 버튼 활성화
- 댓글 등록 기능 구현 (등록 후 캐시 무효화로 즉시 반영)
- 로딩/에러 상태 처리

API 연동 (tradeDiaryApi.ts)
- useMyDiariesQuery — GET /api/diaries/my 목록 조회 훅
- useDiaryDetailQuery — GET /api/diaries/:id 상세 조회 훅 (diaryId 없을 시 비활성화)
- usePostCommentMutation — POST /api/diaries/:id/comments 댓글 등록 훅 (성공 시 상세 쿼리 invalidate)
타입 정의: MyDiariesItem, DiaryDetail, DiaryComment

## 📸 스크린샷(선택)


## 📝 기타
- 수익/손실 색상 컨벤션: 수익(양수) → 빨간색, 손실(음수) → 파란색 (주식 앱 관례)
- 댓글 수정/삭제 버튼 UI는 구현됐으나, 수정 기능과 타인 댓글 삭제 버튼은 비활성 상태(invalid variant)로 처리