### PR TITLE
[Feat] 모의투자 종목 상세 페이지 구현

### DIFF
--- a/src/api/stockApi.ts
+++ b/src/api/stockApi.ts
@@ -1,8 +1,8 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchClient } from "@/lib/fetchClient";
 import type { ApiResponse } from "./authApi";
 
-// ─── Types ────────────────────────────────────────────────────────────────────
+// ─── Types: 종목 목록 ─────────────────────────────────────────────────────────
 
 export type StockItem = {
   tickerCode: string;
@@ -24,10 +24,100 @@ export type StockItemMessage = {
   };
 };
 
+// ─── Types: 종목 현재가/상세 (GET /api/stocks/{stockCode}/quote) ───────────────
+
+export type StockQuote = {
+  stockCode: string;
+  stockName: string;
+  currentPrice: number;
+  changePrice: number;          // 전일 대비
+  changeRate: number;           // 등락률 (%)
+  previousClosePrice: number;   // 전일종가
+  openPrice: number;            // 시가
+  highPrice: number;            // 고가
+  lowPrice: number;             // 저가
+  volume: number;               // 거래량
+  total: number;                // 시가총액
+};
+
+// ─── Types: 종목 보유현황 (GET /api/stocks/{stockCode}/holding) ───────────────
+
+export type StockHolding = {
+  holdingQuantity: number;
+  availableSellQuantity: number;
+  averageBuyPrice: number;
+  evaluationAmount: number;
+  profitAmount: number;
+  profitRate: number;
+};
+
+// ─── Types: 호가 (GET /api/stocks/{stockCode}/orderbook) ─────────────────────
+
+export type OrderBookEntry = {
+  price: number;
+  quantity: number;
+};
+
+export type OrderBookData = {
+  stockCode: string;
+  currentPrice: number;
+  changeRate: number;
+  sellLevels: OrderBookEntry[]; // 매도호가 (파랑, 위) — 높은 가격순
+  buyLevels: OrderBookEntry[];  // 매수호가 (빨강, 아래) — 높은 가격순
+  timestamp: string;
+};
+
+// ─── Types: 종목별 거래내역 (GET /api/trades/{tickerCode}) ────────────────────
+
+export type StockTradeOrder = {
+  orderId: number;
+  side: "BUY" | "SELL";
+  sideLabel: string;
+  orderType: "MARKET" | "LIMIT";
+  orderTypeLabel: string;
+  orderPrice: number;
+  quantity: number;
+  orderAmount: number;
+  status: string;
+  statusLabel: string;
+  cancelable: boolean;
+};
+
+export type StockTradeHistory = {
+  stockCode: string;
+  stockName: string;
+  orders: StockTradeOrder[];
+};
+
+// ─── Types: 매수/매도 주문 (POST /api/trades/buy|sell) ───────────────────────
+
+export type TradeOrderRequest = {
+  ticker: string;
+  orderType: "MARKET" | "LIMIT";
+  price?: number;
+  quantity: number;
+  diary?: string;
+};
+
+export type TradeOrderResponse = {
+  orderId: number;
+  ticker: string;
+  orderType: string;
+  tradeType: string;
+  price: number;
+  quantity: number;
+  status: string;
+};
+
 // ─── Query Keys ───────────────────────────────────────────────────────────────
 
 export const stockQueryKeys = {
   stocks: ["stocks"] as const,
+  quote: (code: string) => ["stocks", code, "quote"] as const,
+  holding: (code: string) => ["stocks", code, "holding"] as const,
+  orderBook: (code: string) => ["stocks", code, "orderbook"] as const,
+  tradeHistory: (code: string) => ["trades", code] as const,
+  cash: ["holdings", "cash"] as const,
 };
 
 // ─── React Query Hooks ────────────────────────────────────────────────────────
@@ -42,6 +132,107 @@ export function useStocksQuery() {
     staleTime: 30_000,
   });
 }
+
+export function useStockQuoteQuery(stockCode: string) {
+  return useQuery({
+    queryKey: stockQueryKeys.quote(stockCode),
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<StockQuote>>(`/api/stocks/${stockCode}/quote`)
+        .then((res) => res.data),
+    staleTime: 5_000,
+    enabled: !!stockCode,
+  });
+}
+
+export function useStockHoldingQuery(stockCode: string) {
+  return useQuery({
+    queryKey: stockQueryKeys.holding(stockCode),
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<StockHolding>>(`/api/stocks/${stockCode}/holding`)
+        .then((res) => res.data),
+    staleTime: 10_000,
+    enabled: !!stockCode,
+  });
+}
+
+export function useCashBalanceQuery() {
+  return useQuery({
+    queryKey: stockQueryKeys.cash,
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<number>>("/api/holdings/cash")
+        .then((res) => res.data),
+    staleTime: 10_000,
+  });
+}
+
+export function useOrderBookQuery(stockCode: string) {
+  return useQuery({
+    queryKey: stockQueryKeys.orderBook(stockCode),
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<OrderBookData>>(`/api/stocks/${stockCode}/orderbook`)
+        .then((res) => res.data),
+    staleTime: 2_000,
+    enabled: !!stockCode,
+    refetchInterval: 3_000,
+  });
+}
+
+export function useStockTradeHistoryQuery(tickerCode: string) {
+  return useQuery({
+    queryKey: stockQueryKeys.tradeHistory(tickerCode),
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<StockTradeHistory>>(`/api/trades/${tickerCode}`)
+        .then((res) => res.data),
+    staleTime: 5_000,
+    enabled: !!tickerCode,
+  });
+}
+
+// ─── Mutation Hooks ───────────────────────────────────────────────────────────
+
+export function useBuyOrderMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: TradeOrderRequest) =>
+      fetchClient.post<ApiResponse<TradeOrderResponse>>("/api/trades/buy", body).then((res) => res.data),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: stockQueryKeys.tradeHistory(variables.ticker) });
+      queryClient.invalidateQueries({ queryKey: stockQueryKeys.holding(variables.ticker) });
+      queryClient.invalidateQueries({ queryKey: stockQueryKeys.cash });
+    },
+  });
+}
+
+export function useSellOrderMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: TradeOrderRequest) =>
+      fetchClient.post<ApiResponse<TradeOrderResponse>>("/api/trades/sell", body).then((res) => res.data),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: stockQueryKeys.tradeHistory(variables.ticker) });
+      queryClient.invalidateQueries({ queryKey: stockQueryKeys.holding(variables.ticker) });
+      queryClient.invalidateQueries({ queryKey: stockQueryKeys.cash });
+    },
+  });
+}
+
+export function useCancelOrderMutation(tickerCode: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (orderId: number) =>
+      fetchClient.patch<ApiResponse<void>>(`/api/v1/orders/${orderId}/cancel`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: stockQueryKeys.tradeHistory(tickerCode) });
+    },
+  });
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const S3_BASE_URL = import.meta.env.VITE_S3_BASE_URL ?? "";
 

--- a/src/api/stockApi.ts
+++ b/src/api/stockApi.ts
@@ -179,9 +179,8 @@ export function useOrderBookQuery(stockCode: string) {
       fetchClient
         .get<ApiResponse<OrderBookData>>(`/api/stocks/${stockCode}/orderbook`)
         .then((res) => res.data),
-    staleTime: 2_000,
+    staleTime: 60_000,
     enabled: !!stockCode,
-    refetchInterval: 3_000,
   });
 }
 

--- a/src/components/stocks/HoldingStatus.tsx
+++ b/src/components/stocks/HoldingStatus.tsx
@@ -1,0 +1,85 @@
+import type { StockHolding } from "@/api/stockApi";
+
+function formatWon(amount: number): string {
+  const abs = Math.abs(amount);
+  if (abs >= 100_000_000) return `${(amount / 100_000_000).toFixed(1)}억원`;
+  if (abs >= 10_000) return `${(amount / 10_000).toFixed(1)}만원`;
+  return `${amount.toLocaleString()}원`;
+}
+
+interface Props {
+  holding: StockHolding | undefined;
+  cash: number | undefined;
+  onBuy: () => void;
+  onSell: () => void;
+}
+
+export default function HoldingStatus({ holding, cash, onBuy, onSell }: Props) {
+  const isPositive = (holding?.profitRate ?? 0) > 0;
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 p-4 flex flex-col gap-4">
+      <div>
+        <h3 className="text-[14px] font-semibold text-gray-900 mb-3">내 보유 현황</h3>
+        {holding && holding.holdingQuantity > 0 ? (
+          <div className="flex flex-col gap-2">
+            {[
+              { label: "보유수량", value: `${holding.holdingQuantity}주` },
+              { label: "평균매수가", value: `${holding.averageBuyPrice.toLocaleString()}원` },
+              { label: "평가금액", value: formatWon(holding.evaluationAmount) },
+              {
+                label: "평가손익",
+                value: `${holding.profitAmount >= 0 ? "+" : ""}${formatWon(holding.profitAmount)}`,
+                colored: true,
+              },
+              {
+                label: "수익률",
+                value: `${holding.profitRate >= 0 ? "+" : ""}${holding.profitRate.toFixed(2)}%`,
+                colored: true,
+              },
+            ].map(({ label, value, colored }) => (
+              <div key={label} className="flex justify-between items-center">
+                <span className="text-[13px] text-gray-400">{label}</span>
+                <span
+                  className={`text-[13px] font-medium ${
+                    colored
+                      ? isPositive
+                        ? "text-red-500"
+                        : "text-blue-500"
+                      : "text-gray-900"
+                  }`}
+                >
+                  {value}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-[13px] text-gray-400">보유 종목 없음</p>
+        )}
+      </div>
+
+      <div className="border-t border-gray-100 pt-3">
+        <p className="text-[13px] text-gray-400 mb-1">보유 현금</p>
+        <p className="text-[18px] font-bold text-gray-900">
+          {cash != null ? `${cash.toLocaleString()}원` : "-"}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          onClick={onBuy}
+          className="py-2.5 rounded-xl bg-red-500 text-white text-[14px] font-semibold hover:bg-red-600 transition-colors cursor-pointer"
+        >
+          매수
+        </button>
+        <button
+          onClick={onSell}
+          className="py-2.5 rounded-xl bg-[#0046FF] text-white text-[14px] font-semibold hover:bg-blue-700 transition-colors cursor-pointer"
+        >
+          매도
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/stocks/OrderBook.tsx
+++ b/src/components/stocks/OrderBook.tsx
@@ -1,0 +1,47 @@
+import type { OrderBookData } from "@/api/stockApi";
+
+interface Props {
+  orderBook: OrderBookData;
+}
+
+export default function OrderBook({ orderBook }: Props) {
+  const { sellLevels, buyLevels, currentPrice, changeRate } = orderBook;
+  const isPositive = changeRate > 0;
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 p-4">
+      <h3 className="text-[14px] font-semibold text-gray-900 mb-3">호가 (10단계)</h3>
+      <div className="flex flex-col text-[13px]">
+        {/* 매도호가 — 파랑, 높은 가격이 위 */}
+        {sellLevels.map((level, i) => (
+          <div key={i} className="flex justify-between py-1.5 border-b border-gray-50">
+            <span className="text-blue-500 font-medium tabular-nums">
+              {level.price.toLocaleString()}
+            </span>
+            <span className="text-gray-400 tabular-nums">{level.quantity.toLocaleString()}</span>
+          </div>
+        ))}
+
+        {/* 현재가 */}
+        <div className="flex justify-between py-2 bg-gray-50 px-1 my-0.5 rounded">
+          <span className="font-bold text-gray-900 tabular-nums">
+            {currentPrice.toLocaleString()}
+          </span>
+          <span className={`font-semibold tabular-nums ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+            {isPositive ? "+" : ""}{changeRate.toFixed(2)}%
+          </span>
+        </div>
+
+        {/* 매수호가 — 빨강, 높은 가격이 위 */}
+        {buyLevels.map((level, i) => (
+          <div key={i} className="flex justify-between py-1.5 border-b border-gray-50">
+            <span className="text-red-500 font-medium tabular-nums">
+              {level.price.toLocaleString()}
+            </span>
+            <span className="text-gray-400 tabular-nums">{level.quantity.toLocaleString()}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/stocks/OrderBook.tsx
+++ b/src/components/stocks/OrderBook.tsx
@@ -12,10 +12,10 @@ export default function OrderBook({ orderBook }: Props) {
     <div className="bg-white rounded-2xl border border-gray-100 p-4">
       <h3 className="text-[14px] font-semibold text-gray-900 mb-3">호가 (10단계)</h3>
       <div className="flex flex-col text-[13px]">
-        {/* 매도호가 — 파랑, 높은 가격이 위 */}
+        {/* 매도호가 — 빨강, 높은 가격이 위 */}
         {sellLevels.map((level, i) => (
           <div key={i} className="flex justify-between py-1.5 border-b border-gray-50">
-            <span className="text-blue-500 font-medium tabular-nums">
+            <span className="text-red-500 font-medium tabular-nums">
               {level.price.toLocaleString()}
             </span>
             <span className="text-gray-400 tabular-nums">{level.quantity.toLocaleString()}</span>
@@ -32,10 +32,10 @@ export default function OrderBook({ orderBook }: Props) {
           </span>
         </div>
 
-        {/* 매수호가 — 빨강, 높은 가격이 위 */}
+        {/* 매수호가 — 파랑, 높은 가격이 위 */}
         {buyLevels.map((level, i) => (
           <div key={i} className="flex justify-between py-1.5 border-b border-gray-50">
-            <span className="text-red-500 font-medium tabular-nums">
+            <span className="text-blue-500 font-medium tabular-nums">
               {level.price.toLocaleString()}
             </span>
             <span className="text-gray-400 tabular-nums">{level.quantity.toLocaleString()}</span>

--- a/src/components/stocks/StockDetailHeader.tsx
+++ b/src/components/stocks/StockDetailHeader.tsx
@@ -1,0 +1,71 @@
+import { ChevronLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import Avatar from "@/components/ui/Avatar";
+import type { StockDetail } from "@/api/stockApi";
+
+const SECTOR_MAP: Record<string, string> = {
+  INFORMATION_TECHNOLOGY: "반도체",
+  SECONDARY_BATTERY: "2차전지",
+  HEALTHCARE: "바이오",
+  AUTOMOBILE: "자동차",
+  IT: "IT",
+  FINANCIALS: "금융",
+  STEEL_MATERIALS: "철강",
+  ENERGY_CHEMICALS: "화학",
+  TELECOM: "통신",
+  UTILITIES: "가변",
+  CONSTRUCTION: "건설",
+  CONSUMER_STAPLES: "소비재",
+  INDUSTRIALS: "산업재",
+  HEAVY_INDUSTRIES: "중공업",
+  COMMUNICATION_SERVICES: "통신",
+};
+
+interface Props {
+  stock: StockDetail;
+}
+
+export default function StockDetailHeader({ stock }: Props) {
+  const navigate = useNavigate();
+  const isPositive = stock.changeRate > 0;
+  const isNegative = stock.changeRate < 0;
+
+  const changeColor = isPositive
+    ? "text-red-500"
+    : isNegative
+      ? "text-blue-500"
+      : "text-gray-500";
+
+  return (
+    <div className="flex items-center gap-4 pb-5 border-b border-gray-100">
+      <button
+        onClick={() => navigate(-1)}
+        className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 shrink-0"
+      >
+        <ChevronLeft size={20} />
+      </button>
+
+      <Avatar name={stock.stockName} src={stock.stockLogo} size={36} />
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-[18px] font-bold text-gray-900">{stock.stockName}</span>
+          <span className="text-[13px] text-gray-400">{stock.tickerCode}</span>
+          <span className="text-[12px] text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded-md">
+            {SECTOR_MAP[stock.sectorType] ?? stock.sectorType}
+          </span>
+        </div>
+        <div className="flex items-baseline gap-2 mt-0.5">
+          <span className="text-[26px] font-bold text-gray-900">
+            {stock.currentPrice.toLocaleString()}원
+          </span>
+          <span className={`text-[14px] font-semibold ${changeColor}`}>
+            {isPositive ? "▲" : isNegative ? "▼" : ""}
+            {Math.abs(stock.change).toLocaleString()} ({isPositive ? "+" : ""}
+            {stock.changeRate.toFixed(2)}%)
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/stocks/StockInfoGrid.tsx
+++ b/src/components/stocks/StockInfoGrid.tsx
@@ -1,0 +1,42 @@
+import type { StockQuote } from "@/api/stockApi";
+
+function formatVolume(vol: number): string {
+  if (vol >= 100_000_000) return `${(vol / 100_000_000).toFixed(1)}억`;
+  if (vol >= 10_000) return `${Math.round(vol / 10_000).toLocaleString()}만`;
+  return vol.toLocaleString();
+}
+
+function formatMarketCap(cap: number): string {
+  if (cap >= 1_000_000_000_000) return `${(cap / 1_000_000_000_000).toFixed(1)}조원`;
+  if (cap >= 100_000_000) return `${(cap / 100_000_000).toFixed(1)}억원`;
+  return `${cap.toLocaleString()}원`;
+}
+
+interface Props {
+  quote: StockQuote;
+}
+
+export default function StockInfoGrid({ quote }: Props) {
+  const cells = [
+    { label: "시가", value: `${quote.openPrice.toLocaleString()}원`, color: "" },
+    { label: "고가", value: `${quote.highPrice.toLocaleString()}원`, color: "text-red-500" },
+    { label: "저가", value: `${quote.lowPrice.toLocaleString()}원`, color: "text-blue-500" },
+    { label: "전일종가", value: `${quote.previousClosePrice.toLocaleString()}원`, color: "" },
+    { label: "거래량", value: formatVolume(quote.volume), color: "" },
+    { label: "시가총액", value: formatMarketCap(quote.total), color: "" },
+  ];
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 p-5">
+      <h3 className="text-[15px] font-semibold text-gray-900 mb-4">종목 정보</h3>
+      <div className="grid grid-cols-3 gap-px bg-gray-100 rounded-xl overflow-hidden">
+        {cells.map(({ label, value, color }) => (
+          <div key={label} className="bg-white px-4 py-3">
+            <p className="text-[12px] text-gray-400 mb-1">{label}</p>
+            <p className={`text-[15px] font-semibold ${color || "text-gray-900"}`}>{value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/stocks/TradeHistory.tsx
+++ b/src/components/stocks/TradeHistory.tsx
@@ -1,0 +1,85 @@
+import type { StockTradeOrder } from "@/api/stockApi";
+import { useCancelOrderMutation } from "@/api/stockApi";
+
+function formatAmount(amount: number): string {
+  if (amount >= 100_000_000) return `${(amount / 100_000_000).toFixed(1)}억원`;
+  if (amount >= 10_000) return `${(amount / 10_000).toFixed(1)}만원`;
+  return `${amount.toLocaleString()}원`;
+}
+
+interface Props {
+  tickerCode: string;
+  orders: StockTradeOrder[];
+}
+
+export default function TradeHistory({ tickerCode, orders }: Props) {
+  const { mutate: cancelOrder, isPending } = useCancelOrderMutation(tickerCode);
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 p-5">
+      <h3 className="text-[15px] font-semibold text-gray-900 mb-4">거래 내역</h3>
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-gray-100">
+            {["구분", "주문유형", "주문가격", "수량", "주문금액", "상태"].map((h) => (
+              <th key={h} className="text-left pb-2.5 text-[12px] text-gray-400 font-medium">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-50">
+          {orders.length === 0 ? (
+            <tr>
+              <td colSpan={6} className="text-center py-10 text-[13px] text-gray-400">
+                거래 내역이 없습니다.
+              </td>
+            </tr>
+          ) : (
+            orders.map((order) => (
+              <tr key={order.orderId} className="hover:bg-gray-50/50">
+                <td className="py-3">
+                  <span
+                    className={`text-[13px] font-semibold ${
+                      order.side === "BUY" ? "text-red-500" : "text-blue-500"
+                    }`}
+                  >
+                    {order.sideLabel}
+                  </span>
+                </td>
+                <td className="py-3 text-[13px] text-gray-600">{order.orderTypeLabel}</td>
+                <td className="py-3 text-[13px] text-gray-900">
+                  {order.orderPrice.toLocaleString()}원
+                </td>
+                <td className="py-3 text-[13px] text-gray-900">{order.quantity}주</td>
+                <td className="py-3 text-[13px] text-gray-900">
+                  {formatAmount(order.orderAmount)}
+                </td>
+                <td className="py-3">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`text-[13px] ${
+                        order.status === "CANCELLED" ? "text-gray-400" : "text-gray-700"
+                      }`}
+                    >
+                      {order.statusLabel}
+                    </span>
+                    {order.cancelable && (
+                      <button
+                        onClick={() => cancelOrder(order.orderId)}
+                        disabled={isPending}
+                        className="text-[12px] text-gray-400 hover:text-red-500 border border-gray-200 rounded px-1.5 py-0.5 transition-colors disabled:opacity-50"
+                      >
+                        × 취소
+                      </button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/lib/fetchClient.ts
+++ b/src/lib/fetchClient.ts
@@ -63,6 +63,12 @@ export const fetchClient = {
       body: body !== undefined ? JSON.stringify(body) : undefined,
     }),
 
+  patch: <T>(path: string, body?: unknown) =>
+    request<T>(path, {
+      method: "PATCH",
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    }),
+
   delete: <T>(path: string, body?: unknown) =>
     request<T>(path, {
       method: "DELETE",

--- a/src/pages/stocks/StockDetailPage.tsx
+++ b/src/pages/stocks/StockDetailPage.tsx
@@ -1,12 +1,19 @@
+import { useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   useStockQuoteQuery,
   useStockHoldingQuery,
   useCashBalanceQuery,
   useStockTradeHistoryQuery,
   useOrderBookQuery,
+  stockQueryKeys,
 } from "@/api/stockApi";
+import type { StockQuote, StockItemMessage, OrderBookData } from "@/api/stockApi";
+import { useStockStore } from "@/store/stockStore";
 import StockDetailHeader from "@/components/stocks/StockDetailHeader";
 import StockInfoGrid from "@/components/stocks/StockInfoGrid";
 import TradeHistory from "@/components/stocks/TradeHistory";
@@ -16,12 +23,62 @@ import OrderBook from "@/components/stocks/OrderBook";
 export default function StockDetailPage() {
   const { stockCode = "" } = useParams<{ stockCode: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const selectedStock = useStockStore((s) => s.selectedStock);
 
   const { data: quote, isLoading } = useStockQuoteQuery(stockCode);
   const { data: holding } = useStockHoldingQuery(stockCode);
   const { data: cash } = useCashBalanceQuery();
   const { data: tradeHistory } = useStockTradeHistoryQuery(stockCode);
   const { data: orderBook } = useOrderBookQuery(stockCode);
+
+  // ── 실시간 연결 (백엔드 스케줄러가 자동 구독 → STOMP 수신만 하면 됨) ────
+  useEffect(() => {
+    if (!stockCode) return;
+
+    const wsUrl = (import.meta.env.VITE_API_BASE_URL ?? "") + "/ws";
+    const client = new Client({
+      webSocketFactory: () => new SockJS(wsUrl),
+      onConnect: () => {
+        console.log("[STOMP] 종목 상세 연결됨:", stockCode);
+        client.subscribe(`/topic/stocks/${stockCode}/quote`, (message) => {
+          const msg: StockItemMessage = JSON.parse(message.body);
+          queryClient.setQueryData<StockQuote>(
+            stockQueryKeys.quote(stockCode),
+            (prev) =>
+              prev
+                ? {
+                    ...prev,
+                    currentPrice: msg.currentPrice,
+                    changePrice: msg.changePrice,
+                    changeRate: msg.changeRate,
+                    highPrice: msg.highPrice,
+                    lowPrice: msg.lowPrice,
+                    volume: msg.volume,
+                  }
+                : prev,
+          );
+        });
+
+        client.subscribe(`/topic/orderbook/${stockCode}`, (message) => {
+          const raw = JSON.parse(message.body);
+          console.log("[STOMP] 호가 원본:", JSON.stringify(raw));
+          const msg: OrderBookData = raw.data ?? raw;
+          queryClient.setQueryData<OrderBookData>(
+            stockQueryKeys.orderBook(stockCode),
+            msg,
+          );
+        });
+      },
+      onDisconnect: () => console.log("[STOMP] 종목 상세 연결 끊김"),
+      onStompError: (frame) => console.error("[STOMP] 에러:", frame),
+    });
+    client.activate();
+
+    return () => {
+      client.deactivate();
+    };
+  }, [stockCode, queryClient]);
 
   if (isLoading) {
     return (
@@ -39,12 +96,11 @@ export default function StockDetailPage() {
     );
   }
 
-  // StockDetailHeader는 StockQuote 기반으로 구성
   const headerStock = {
     tickerCode: quote.stockCode,
     stockName: quote.stockName,
-    stockLogo: "",
-    sectorType: "",
+    stockLogo: selectedStock?.stockLogo ?? "",
+    sectorType: selectedStock?.sectorType ?? "",
     currentPrice: quote.currentPrice,
     change: quote.changePrice,
     changeRate: quote.changeRate,
@@ -64,7 +120,7 @@ export default function StockDetailPage() {
         {/* 왼쪽 */}
         <div className="flex flex-col gap-5 flex-1 min-w-0">
           {/* 차트 — 추후 구현 */}
-          <div className="bg-white rounded-2xl border border-gray-100 h-[300px] flex items-center justify-center text-[14px] text-gray-300">
+          <div className="bg-white rounded-2xl border border-gray-100 h-75 flex items-center justify-center text-[14px] text-gray-300">
             주가 차트 준비 중
           </div>
 
@@ -77,7 +133,7 @@ export default function StockDetailPage() {
         </div>
 
         {/* 오른쪽 */}
-        <div className="w-[240px] shrink-0 flex flex-col gap-4">
+        <div className="w-60 shrink-0 flex flex-col gap-4">
           <HoldingStatus
             holding={holding}
             cash={cash}

--- a/src/pages/stocks/StockDetailPage.tsx
+++ b/src/pages/stocks/StockDetailPage.tsx
@@ -1,0 +1,92 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { Loader2 } from "lucide-react";
+import {
+  useStockQuoteQuery,
+  useStockHoldingQuery,
+  useCashBalanceQuery,
+  useStockTradeHistoryQuery,
+  useOrderBookQuery,
+} from "@/api/stockApi";
+import StockDetailHeader from "@/components/stocks/StockDetailHeader";
+import StockInfoGrid from "@/components/stocks/StockInfoGrid";
+import TradeHistory from "@/components/stocks/TradeHistory";
+import HoldingStatus from "@/components/stocks/HoldingStatus";
+import OrderBook from "@/components/stocks/OrderBook";
+
+export default function StockDetailPage() {
+  const { stockCode = "" } = useParams<{ stockCode: string }>();
+  const navigate = useNavigate();
+
+  const { data: quote, isLoading } = useStockQuoteQuery(stockCode);
+  const { data: holding } = useStockHoldingQuery(stockCode);
+  const { data: cash } = useCashBalanceQuery();
+  const { data: tradeHistory } = useStockTradeHistoryQuery(stockCode);
+  const { data: orderBook } = useOrderBookQuery(stockCode);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-screen">
+        <Loader2 size={32} className="animate-spin text-[#0046FF]" />
+      </div>
+    );
+  }
+
+  if (!quote) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-screen text-[14px] text-gray-400">
+        종목 정보를 불러올 수 없습니다.
+      </div>
+    );
+  }
+
+  // StockDetailHeader는 StockQuote 기반으로 구성
+  const headerStock = {
+    tickerCode: quote.stockCode,
+    stockName: quote.stockName,
+    stockLogo: "",
+    sectorType: "",
+    currentPrice: quote.currentPrice,
+    change: quote.changePrice,
+    changeRate: quote.changeRate,
+    open: quote.openPrice,
+    high: quote.highPrice,
+    low: quote.lowPrice,
+    prevClose: quote.previousClosePrice,
+    volume: quote.volume,
+    marketCap: quote.total,
+  };
+
+  return (
+    <div className="flex flex-col p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
+      <StockDetailHeader stock={headerStock} />
+
+      <div className="flex gap-5 items-start">
+        {/* 왼쪽 */}
+        <div className="flex flex-col gap-5 flex-1 min-w-0">
+          {/* 차트 — 추후 구현 */}
+          <div className="bg-white rounded-2xl border border-gray-100 h-[300px] flex items-center justify-center text-[14px] text-gray-300">
+            주가 차트 준비 중
+          </div>
+
+          <StockInfoGrid quote={quote} />
+
+          <TradeHistory
+            tickerCode={stockCode}
+            orders={tradeHistory?.orders ?? []}
+          />
+        </div>
+
+        {/* 오른쪽 */}
+        <div className="w-[240px] shrink-0 flex flex-col gap-4">
+          <HoldingStatus
+            holding={holding}
+            cash={cash}
+            onBuy={() => navigate(`/invest/${stockCode}/buy`)}
+            onSell={() => navigate(`/invest/${stockCode}/sell`)}
+          />
+          {orderBook && <OrderBook orderBook={orderBook} />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/stocks/StockList.tsx
+++ b/src/pages/stocks/StockList.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Search, TrendingUp, TrendingDown } from "lucide-react";
 import Avatar from "@/components/ui/Avatar";
+import { useStockStore } from "@/store/stockStore";
 
 import { useMarketIndicesQuery } from "@/api/homeApi";
 import { fetchStocks, parseStockItemMessage } from "@/api/stockApi";
@@ -87,9 +89,9 @@ function MarketPanel({
 
 // ─── 종목 행 ──────────────────────────────────────────────────────────────────
 
-function StockRow({ stock }: { stock: StockItem }) {
+function StockRow({ stock, onClick }: { stock: StockItem; onClick: () => void }) {
   return (
-    <tr className="hover:bg-gray-50/50 transition-colors">
+    <tr className="hover:bg-gray-50/50 transition-colors cursor-pointer" onClick={onClick}>
       <td className="px-5 py-3.5">
         <div className="flex items-center gap-3">
           <Avatar
@@ -124,10 +126,10 @@ function StockRow({ stock }: { stock: StockItem }) {
         </span>
       </td>
       <td className="px-4 py-3.5 text-right text-[14px] font-semibold text-gray-900">
-        {stock.volume.toLocaleString()}
+        {stock.volume?.toLocaleString() ?? "-"}
       </td>
       <td className="px-4 py-3.5 text-right text-[14px] font-semibold text-gray-900">
-        {stock.total.toLocaleString()}
+        {stock.total?.toLocaleString() ?? "-"}
       </td>
     </tr>
   );
@@ -136,6 +138,8 @@ function StockRow({ stock }: { stock: StockItem }) {
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function StockList() {
+  const navigate = useNavigate();
+  const setSelectedStock = useStockStore((s) => s.setSelectedStock);
   const { data: marketIndices = [], isLoading: loadingMarket } =
     useMarketIndicesQuery();
 
@@ -289,7 +293,14 @@ export default function StockList() {
           <tbody className="divide-y divide-gray-50">
             {filtered.length > 0 ? (
               filtered.map((stock) => (
-                <StockRow key={stock.tickerCode} stock={stock} />
+                <StockRow
+                  key={stock.tickerCode}
+                  stock={stock}
+                  onClick={() => {
+                    setSelectedStock(stock);
+                    navigate(`/invest/${stock.tickerCode}`);
+                  }}
+                />
               ))
             ) : (
               <tr>

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -6,6 +6,7 @@ import LoginPage from "@/pages/auth/LoginPage";
 import SignUpPage from "@/pages/auth/SignUpPage";
 import OAuthCallbackPage from "@/pages/auth/OauthCallbackPage";
 import StockList from "@/pages/stocks/StockList";
+import StockDetailPage from "@/pages/stocks/StockDetailPage";
 import ProtectedRoute from "./ProtectedRoute";
 import TradeDiaryPage from "@/pages/trade-diaries/TradeDiaryPage";
 import DiaryDetailPage from "@/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPage";
@@ -19,7 +20,13 @@ export const router = createBrowserRouter([
         element: <Layout />,
         children: [
           { index: true, element: <HomePage /> },
-          { path: "invest", element: <StockList /> },
+          {
+            path: "invest",
+            children: [
+              { index: true, element: <StockList /> },
+              { path: ":stockCode", element: <StockDetailPage /> },
+            ],
+          },
           { path: "components", element: <ComponentsPage /> },
           {
             path: "trade-diary",

--- a/src/store/stockStore.ts
+++ b/src/store/stockStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+import type { StockItem } from "@/api/stockApi";
+
+interface StockState {
+  // 목록에서 상세로 넘어갈 때 기본 정보 유지  
+  selectedStock: StockItem | null;
+  setSelectedStock: (stock: StockItem) => void;
+  clearSelectedStock: () => void;
+}
+
+export const useStockStore = create<StockState>((set) => ({
+  selectedStock: null,
+  setSelectedStock: (stock) => set({ selectedStock: stock }),
+  clearSelectedStock: () => set({ selectedStock: null }),
+}));


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #6 

# 💡 작업 배경
모의투자 서비스의 핵심 화면인 종목 목록과 종목 상세 페이지를 구현

## 🧩 작업 내용
- stockApi.ts: 종목 목록/현재가/보유현황/호가/거래내역/매수·매도·취소 API 및 React Query 훅 구현
- Zustand stockStore: 목록→상세 전환 시 선택 종목 유지
- 컴포넌트: StockDetailHeader, StockInfoGrid, OrderBook, TradeHistory, HoldingStatus
- StockDetailPage: 위 컴포넌트 조합 및 STOMP WebSocket 실시간 연결
  - `/topic/stocks/{code}/quote` → 현재가·고가·저가·거래량 실시간 업데이트
  - `/topic/orderbook/{code}` → 호가 실시간 업데이트
- StockList: 종목 클릭 시 상세 페이지로 네비게이션 연결

## 📸 스크린샷 (선택)
<img width="1313" height="823" alt="Screenshot 2026-03-25 at 5 16 39 PM" src="https://github.com/user-attachments/assets/a9922e1f-5631-4af4-b440-02dac34b719e" />

## 📝 기타
종목 상세에 나오는 차트는 추후 다른 이슈에서 진행할 예정입니다.