### PR TITLE
[Feat] 유저 목록 페이지 구현

### DIFF
--- a/src/api/accountSummaryApi.ts
+++ b/src/api/accountSummaryApi.ts
@@ -1,0 +1,45 @@
+import { fetchClient } from "@/lib/fetchClient";
+import { useQuery } from "@tanstack/react-query";
+import type { ApiResponse } from "./authApi";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type HoldingRatio = {
+  tickerCode: string;
+  stockName: string;
+  evaluation: number;
+  ratio: number;
+};
+
+export type AccountSummaryData = {
+  totalAsset: number;
+  totalAssetChangeAmount: number;
+  totalAssetChangeRate: number;
+  cash: number;
+  initialCash: number;
+  holdingsCount: number;
+  totalEvaluation: number;
+  totalReturnRate: number;
+  totalReturnAmount: number;
+  holdingsRatio: HoldingRatio[];
+};
+
+// ─── Query Keys ───────────────────────────────────────────────────────────────
+
+export const accountSummaryQueryKeys = {
+  summary: ["account-summary"] as const,
+};
+
+// ─── React Query Hook ─────────────────────────────────────────────────────────
+
+export function useAccountSummaryQuery() {
+  return useQuery({
+    queryKey: accountSummaryQueryKeys.summary,
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<AccountSummaryData>>("/api/account/summary")
+        .then((res) => res.data),
+    staleTime: 0,
+    refetchInterval: 10_000,
+  });
+}

--- a/src/api/accountSummaryApi.ts
+++ b/src/api/accountSummaryApi.ts
@@ -43,3 +43,14 @@ export function useAccountSummaryQuery() {
     refetchInterval: 10_000,
   });
 }
+
+export function useAccountSummaryByUserQuery(userId: number) {
+  return useQuery({
+    queryKey: ["account-summary", userId],
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<AccountSummaryData>>(`/api/account/summary/${userId}`)
+        .then((res) => res.data),
+    staleTime: 30_000,
+  });
+}

--- a/src/api/userListApi.ts
+++ b/src/api/userListApi.ts
@@ -1,0 +1,53 @@
+import { fetchClient } from "@/lib/fetchClient";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import type { ApiResponse } from "./authApi";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type MentoringStatus = "NONE" | "PENDING" | "ACCEPTED";
+
+export type UserItem = {
+  userId: number;
+  nickname: string;
+  imageUrl: string;
+  followerCount: number;
+  followingCount: number;
+  mentoringStatus: MentoringStatus;
+  me: boolean;
+  following: boolean;
+};
+
+export type UserListData = {
+  hasAcceptedMentor: boolean;
+  users: UserItem[];
+  nextCursor: number | null;
+  hasNext: boolean;
+};
+
+// ─── Query Keys ───────────────────────────────────────────────────────────────
+
+export const userListQueryKeys = {
+  userList: ["user-list"] as const,
+};
+
+// ─── API ─────────────────────────────────────────────────────────────────────
+
+async function fetchUserList(cursor?: number): Promise<UserListData> {
+  const params = cursor !== undefined ? `?cursor=${cursor}` : "";
+  const res = await fetchClient.get<ApiResponse<UserListData>>(
+    `/api/users${params}`,
+  );
+  return res.data;
+}
+
+// ─── React Query Hook ─────────────────────────────────────────────────────────
+
+export function useUserListInfiniteQuery() {
+  return useInfiniteQuery({
+    queryKey: userListQueryKeys.userList,
+    queryFn: ({ pageParam }) => fetchUserList(pageParam as number | undefined),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
+  });
+}

--- a/src/api/userListApi.ts
+++ b/src/api/userListApi.ts
@@ -1,5 +1,5 @@
 import { fetchClient } from "@/lib/fetchClient";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiResponse } from "./authApi";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -38,6 +38,67 @@ async function fetchUserList(cursor?: number): Promise<UserListData> {
     `/api/users${params}`,
   );
   return res.data;
+}
+
+export async function followUser(userId: number): Promise<void> {
+  await fetchClient.post(`/api/follows/${userId}`);
+}
+
+export async function unfollowUser(userId: number): Promise<void> {
+  await fetchClient.delete(`/api/follows/${userId}`);
+}
+
+export async function requestMentoring(mentorUserId: number): Promise<void> {
+  await fetchClient.post("/api/mentor-requests", { mentorUserId });
+}
+
+export async function cancelMentoring(mentorUserId: number): Promise<void> {
+  await fetchClient.delete(`/api/mentor-requests/${mentorUserId}`);
+}
+
+// ─── Cache Updater ────────────────────────────────────────────────────────────
+
+type InfiniteData = { pages: UserListData[]; pageParams: unknown[] };
+
+export function useUserListCacheUpdate() {
+  const queryClient = useQueryClient();
+
+  function updateCache(updater: (data: InfiniteData) => InfiniteData) {
+    queryClient.setQueryData<InfiniteData>(userListQueryKeys.userList, (old) =>
+      old ? updater(old) : old,
+    );
+  }
+
+  function toggleFollow(userId: number, newFollowing: boolean) {
+    updateCache((old) => ({
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        users: page.users.map((u) =>
+          u.userId === userId ? { ...u, following: newFollowing } : u,
+        ),
+      })),
+    }));
+  }
+
+  function setMentoringStatus(
+    userId: number,
+    status: MentoringStatus,
+    hasAcceptedMentor: boolean,
+  ) {
+    updateCache((old) => ({
+      ...old,
+      pages: old.pages.map((page, i) => ({
+        ...page,
+        hasAcceptedMentor: i === 0 ? hasAcceptedMentor : page.hasAcceptedMentor,
+        users: page.users.map((u) =>
+          u.userId === userId ? { ...u, mentoringStatus: status } : u,
+        ),
+      })),
+    }));
+  }
+
+  return { toggleFollow, setMentoringStatus };
 }
 
 // ─── React Query Hook ─────────────────────────────────────────────────────────

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -3,6 +3,7 @@ type ButtonProps = {
   variant?: "primary" | "basic" | "invalid";
   width?: number;
   className?: string;
+  disabled?: boolean;
   onClick?: () => void;
 };
 
@@ -17,6 +18,7 @@ export default function Button({
   variant = "primary",
   width,
   className,
+  disabled,
   onClick,
 }: ButtonProps) {
   return (
@@ -28,6 +30,7 @@ export default function Button({
         variantClass[variant],
         className,
       ].join(" ")}
+      disabled={disabled}
       onClick={onClick}
     >
       {children}

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -1,0 +1,296 @@
+import { useRef, useCallback, useState } from "react";
+import { Search } from "lucide-react";
+import Avatar from "@/components/ui/Avatar";
+import Button from "@/components/ui/Button";
+import { useUserListInfiniteQuery } from "@/api/userListApi";
+import type { UserItem } from "@/api/userListApi";
+
+// ─── Utils ────────────────────────────────────────────────────────────────────
+
+const AVATAR_COLORS = [
+  "#4ECDC4", "#45B7D1", "#FF6B35", "#96CEB4", "#DDA0DD",
+  "#BB8FCE", "#85C1E9", "#F0A500", "#E74C3C", "#2ECC71",
+];
+
+function getAvatarColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
+// ─── Podium ───────────────────────────────────────────────────────────────────
+
+const PODIUM_CONFIG = {
+  1: { barHeight: "h-24", barBg: "bg-yellow-400" },
+  2: { barHeight: "h-16", barBg: "bg-gray-400"   },
+  3: { barHeight: "h-12", barBg: "bg-orange-400" },
+} as const;
+
+function PodiumSlot({ user, rank }: { user: UserItem; rank: 1 | 2 | 3 }) {
+  const cfg = PODIUM_CONFIG[rank];
+  return (
+    <div className="flex flex-col items-center">
+      {rank === 1 && <span className="text-xl mb-1">👑</span>}
+      <Avatar
+        name={user.nickname}
+        src={user.imageUrl || undefined}
+        size={rank === 1 ? 56 : 44}
+        color={getAvatarColor(user.nickname)}
+      />
+      <p className="text-[13px] font-medium text-gray-800 mt-1.5 max-w-20 text-center truncate">
+        {user.nickname}
+      </p>
+      <div
+        className={`w-20 rounded-t-xl mt-2 flex items-center justify-center ${cfg.barHeight} ${cfg.barBg}`}
+      >
+        <span className="text-white text-[20px] font-bold">{rank}</span>
+      </div>
+    </div>
+  );
+}
+
+function Podium({ users }: { users: UserItem[] }) {
+  const [second, first, third] = [users[1], users[0], users[2]];
+  return (
+    <div className="flex items-end justify-center gap-3 py-6 bg-gray-50 rounded-2xl mb-4">
+      {second && <PodiumSlot user={second} rank={2} />}
+      {first  && <PodiumSlot user={first}  rank={1} />}
+      {third  && <PodiumSlot user={third}  rank={3} />}
+    </div>
+  );
+}
+
+// ─── Follow / Mentoring Buttons ───────────────────────────────────────────────
+
+function FollowButton({ user }: { user: UserItem }) {
+  if (user.me) return null;
+  return user.following ? (
+    <Button variant="primary" width={64} className="text-[12px]">
+      팔로잉
+    </Button>
+  ) : (
+    <Button variant="basic" width={64} className="text-[12px]">
+      팔로우
+    </Button>
+  );
+}
+
+function MentoringButton({
+  user,
+  hasAcceptedMentor,
+}: {
+  user: UserItem;
+  hasAcceptedMentor: boolean;
+}) {
+  if (user.me) return null;
+
+  if (user.mentoringStatus === "ACCEPTED") {
+    return (
+      <Button variant="primary" width={72} className="text-[12px] bg-orange-400 hover:bg-orange-500 border-none">
+        멘토
+      </Button>
+    );
+  }
+  if (user.mentoringStatus === "PENDING") {
+    return (
+      <button
+        disabled
+        className="w-18 py-1.5 rounded-[10px] text-[12px] border border-orange-400 text-orange-400 bg-white cursor-default"
+      >
+        신청완료
+      </button>
+    );
+  }
+  return (
+    <Button variant="basic" width={72} className="text-[12px]">
+      <span className={hasAcceptedMentor ? "opacity-40" : ""}>멘토신청</span>
+    </Button>
+  );
+}
+
+// ─── Table Row ────────────────────────────────────────────────────────────────
+
+function UserRow({
+  user,
+  rank,
+  hasAcceptedMentor,
+}: {
+  user: UserItem;
+  rank: number;
+  hasAcceptedMentor: boolean;
+}) {
+  return (
+    <tr className={`border-b border-gray-50 hover:bg-gray-50/50 transition-colors ${user.me ? "bg-blue-50/40" : ""}`}>
+      {/* 순위 */}
+      <td className="px-5 py-3.5 w-12">
+        <span className={`text-[14px] font-bold ${rank <= 3 ? "text-[#0046FF]" : "text-gray-400"}`}>
+          {rank}
+        </span>
+      </td>
+
+      {/* 투자자 */}
+      <td className="px-2 py-3.5">
+        <div className="flex items-center gap-2.5">
+          <Avatar
+            name={user.nickname}
+            src={user.imageUrl || undefined}
+            size={32}
+            color={getAvatarColor(user.nickname)}
+          />
+          <span className="text-[14px] font-medium text-gray-900">{user.nickname}</span>
+          {user.me && (
+            <span className="text-[11px] font-semibold text-white bg-[#0046FF] px-1.5 py-0.5 rounded-full">
+              나
+            </span>
+          )}
+        </div>
+      </td>
+
+      {/* 팔로워 */}
+      <td className="px-4 py-3.5 text-[13px] text-gray-500 text-right">
+        {user.followerCount.toLocaleString()}명
+      </td>
+
+      {/* 팔로우 */}
+      <td className="px-3 py-3.5 text-right">
+        <FollowButton user={user} />
+      </td>
+
+      {/* 멘토신청 */}
+      <td className="px-5 py-3.5 text-right">
+        <MentoringButton user={user} hasAcceptedMentor={hasAcceptedMentor} />
+      </td>
+    </tr>
+  );
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+export default function UserListPage() {
+  const [tab, setTab] = useState<"전체" | "팔로잉">("전체");
+  const [search, setSearch] = useState("");
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useUserListInfiniteQuery();
+
+  const allUsers = data?.pages.flatMap((p) => p.users) ?? [];
+  const hasAcceptedMentor = data?.pages[0]?.hasAcceptedMentor ?? false;
+
+  const filtered = allUsers
+    .filter((u) => tab === "전체" || u.following)
+    .filter((u) => !search || u.nickname.includes(search));
+
+  // ─── Infinite Scroll Sentinel ─────────────────────────────────────────────
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observerRef.current) observerRef.current.disconnect();
+      if (!node) return;
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      });
+      observerRef.current.observe(node);
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  );
+
+  const top3 = filtered.slice(0, 3);
+
+  return (
+    <div className="flex flex-col h-full p-6 gap-4 overflow-auto bg-gray-50 min-h-screen">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center text-[#0046FF]">
+            👥
+          </div>
+          <div>
+            <h1 className="text-[20px] font-bold text-gray-900">유저 목록</h1>
+            <p className="text-[12px] text-gray-400">수익률 기준 투자자 랭킹</p>
+          </div>
+        </div>
+        {/* 검색 */}
+        <div className="flex items-center gap-2 bg-white border border-gray-200 rounded-xl px-3 py-2 w-52">
+          <Search size={14} className="text-gray-400 shrink-0" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="투자자 검색..."
+            className="text-[13px] text-gray-700 bg-transparent outline-none w-full placeholder:text-gray-400"
+          />
+        </div>
+      </div>
+
+      {/* 탭 */}
+      <div className="flex gap-2">
+        {(["전체", "팔로잉"] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={[
+              "px-5 py-2 rounded-lg text-[14px] font-semibold transition-colors",
+              tab === t
+                ? "bg-[#0046FF] text-white"
+                : "bg-white text-gray-500 border border-gray-200 hover:bg-gray-50",
+            ].join(" ")}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {/* 포디움 */}
+      {!isLoading && top3.length >= 3 && <Podium users={top3} />}
+
+      {/* 랭킹 테이블 */}
+      <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="bg-gray-50 border-b border-gray-100">
+              <th className="text-left px-5 py-3 text-[12px] text-gray-400 font-medium">순위</th>
+              <th className="text-left px-2 py-3 text-[12px] text-gray-400 font-medium">투자자</th>
+              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">팔로워</th>
+              <th className="text-right px-3 py-3 text-[12px] text-gray-400 font-medium">팔로우</th>
+              <th className="text-right px-5 py-3 text-[12px] text-gray-400 font-medium">멘토신청</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading
+              ? Array.from({ length: 8 }).map((_, i) => (
+                  <tr key={i} className="border-b border-gray-50 animate-pulse">
+                    <td className="px-5 py-4"><div className="h-3 bg-gray-100 rounded-full w-4" /></td>
+                    <td className="px-2 py-4">
+                      <div className="flex items-center gap-2.5">
+                        <div className="w-8 h-8 bg-gray-100 rounded-full" />
+                        <div className="h-3 bg-gray-100 rounded-full w-24" />
+                      </div>
+                    </td>
+                    <td className="px-4 py-4"><div className="h-3 bg-gray-100 rounded-full w-10 ml-auto" /></td>
+                    <td className="px-3 py-4"><div className="h-7 bg-gray-100 rounded-lg w-16 ml-auto" /></td>
+                    <td className="px-5 py-4"><div className="h-7 bg-gray-100 rounded-lg w-18 ml-auto" /></td>
+                  </tr>
+                ))
+              : filtered.map((user, i) => (
+                  <UserRow
+                    key={user.userId}
+                    user={user}
+                    rank={i + 1}
+                    hasAcceptedMentor={hasAcceptedMentor}
+                  />
+                ))}
+          </tbody>
+        </table>
+
+        {/* 무한 스크롤 센티넬 */}
+        <div ref={sentinelRef} className="h-1" />
+        {isFetchingNextPage && (
+          <div className="flex justify-center py-4">
+            <div className="w-5 h-5 rounded-full border-2 border-[#0046FF] border-t-transparent animate-spin" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -2,8 +2,16 @@ import { useRef, useCallback, useState } from "react";
 import { Search } from "lucide-react";
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
-import { useUserListInfiniteQuery } from "@/api/userListApi";
+import {
+  useUserListInfiniteQuery,
+  useUserListCacheUpdate,
+  followUser,
+  unfollowUser,
+  requestMentoring,
+  cancelMentoring,
+} from "@/api/userListApi";
 import type { UserItem } from "@/api/userListApi";
+import { useAccountSummaryQuery, useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
 
 // ─── Utils ────────────────────────────────────────────────────────────────────
 
@@ -62,14 +70,20 @@ function Podium({ users }: { users: UserItem[] }) {
 
 // ─── Follow / Mentoring Buttons ───────────────────────────────────────────────
 
-function FollowButton({ user }: { user: UserItem }) {
+function FollowButton({
+  user,
+  onToggle,
+}: {
+  user: UserItem;
+  onToggle: (user: UserItem) => void;
+}) {
   if (user.me) return null;
   return user.following ? (
-    <Button variant="primary" width={64} className="text-[12px]">
+    <Button variant="basic" className="text-[12px] w-full" onClick={() => onToggle(user)}>
       팔로잉
     </Button>
   ) : (
-    <Button variant="basic" width={64} className="text-[12px]">
+    <Button variant="primary" className="text-[12px] w-full" onClick={() => onToggle(user)}>
       팔로우
     </Button>
   );
@@ -78,33 +92,86 @@ function FollowButton({ user }: { user: UserItem }) {
 function MentoringButton({
   user,
   hasAcceptedMentor,
+  onRequest,
+  onCancel,
 }: {
   user: UserItem;
   hasAcceptedMentor: boolean;
+  onRequest: (user: UserItem) => void;
+  onCancel: (user: UserItem) => void;
 }) {
   if (user.me) return null;
 
+  // 멘토가 있는 상태에서 다른 사람은 버튼 숨김 (내 멘토만 표시)
+  if (hasAcceptedMentor && user.mentoringStatus !== "ACCEPTED") return null;
+
   if (user.mentoringStatus === "ACCEPTED") {
     return (
-      <Button variant="primary" width={72} className="text-[12px] bg-orange-400 hover:bg-orange-500 border-none">
+      <button
+        disabled
+        className="w-full py-1.5 rounded-[10px] text-[12px] text-white bg-orange-400 cursor-default"
+      >
         멘토
-      </Button>
+      </button>
     );
   }
   if (user.mentoringStatus === "PENDING") {
     return (
       <button
         disabled
-        className="w-18 py-1.5 rounded-[10px] text-[12px] border border-orange-400 text-orange-400 bg-white cursor-default"
+        className="w-full py-1.5 rounded-[10px] text-[12px] border border-orange-400 text-orange-400 bg-white cursor-default opacity-60"
       >
         신청완료
       </button>
     );
   }
   return (
-    <Button variant="basic" width={72} className="text-[12px]">
-      <span className={hasAcceptedMentor ? "opacity-40" : ""}>멘토신청</span>
-    </Button>
+    <button
+      disabled={hasAcceptedMentor}
+      className={`w-full py-1.5 rounded-[10px] text-[12px] text-white bg-orange-400 hover:bg-orange-500 ${hasAcceptedMentor ? "opacity-40 cursor-default" : ""}`}
+      onClick={() => !hasAcceptedMentor && onRequest(user)}
+    >
+      멘토신청
+    </button>
+  );
+}
+
+// ─── Return Rate / Amount Cells ───────────────────────────────────────────────
+
+function ReturnCells({ userId, me }: { userId: number; me: boolean }) {
+  const myQuery = useAccountSummaryQuery();
+  const otherQuery = useAccountSummaryByUserQuery(userId);
+  const { data, isLoading } = me ? myQuery : otherQuery;
+
+  if (isLoading) {
+    return (
+      <>
+        <td className="px-4 py-3.5 text-right">
+          <div className="h-3 bg-gray-100 rounded-full w-14 ml-auto animate-pulse" />
+        </td>
+        <td className="px-4 py-3.5 text-right">
+          <div className="h-3 bg-gray-100 rounded-full w-16 ml-auto animate-pulse" />
+        </td>
+      </>
+    );
+  }
+
+  const rate = data?.totalReturnRate ?? 0;
+  const amount = data?.totalReturnAmount ?? 0;
+  const isPositive = rate > 0;
+  const isNegative = rate < 0;
+  const color = isPositive ? "text-red-500" : isNegative ? "text-blue-500" : "text-gray-400";
+  const prefix = isPositive ? "+" : "";
+
+  return (
+    <>
+      <td className={`px-4 py-3.5 text-[13px] font-medium text-right ${color}`}>
+        {prefix}{rate.toFixed(1)}%
+      </td>
+      <td className={`px-4 py-3.5 text-[13px] font-medium text-right ${color}`}>
+        {prefix}{(amount / 10000).toFixed(0)}만원
+      </td>
+    </>
   );
 }
 
@@ -114,15 +181,21 @@ function UserRow({
   user,
   rank,
   hasAcceptedMentor,
+  onFollowToggle,
+  onMentoringRequest,
+  onMentoringCancel,
 }: {
   user: UserItem;
   rank: number;
   hasAcceptedMentor: boolean;
+  onFollowToggle: (user: UserItem) => void;
+  onMentoringRequest: (user: UserItem) => void;
+  onMentoringCancel: (user: UserItem) => void;
 }) {
   return (
     <tr className={`border-b border-gray-50 hover:bg-gray-50/50 transition-colors ${user.me ? "bg-blue-50/40" : ""}`}>
       {/* 순위 */}
-      <td className="px-5 py-3.5 w-12">
+      <td className="px-5 py-3.5 text-center">
         <span className={`text-[14px] font-bold ${rank <= 3 ? "text-[#0046FF]" : "text-gray-400"}`}>
           {rank}
         </span>
@@ -151,14 +224,22 @@ function UserRow({
         {user.followerCount.toLocaleString()}명
       </td>
 
+      {/* 총 수익률 / 총 수익 */}
+      <ReturnCells userId={user.userId} me={user.me} />
+
       {/* 팔로우 */}
-      <td className="px-3 py-3.5 text-right">
-        <FollowButton user={user} />
+      <td className="px-4 py-3.5 text-center">
+        <FollowButton user={user} onToggle={onFollowToggle} />
       </td>
 
-      {/* 멘토신청 */}
-      <td className="px-5 py-3.5 text-right">
-        <MentoringButton user={user} hasAcceptedMentor={hasAcceptedMentor} />
+      {/* 멘토 */}
+      <td className="px-4 py-3.5 text-center">
+        <MentoringButton
+          user={user}
+          hasAcceptedMentor={hasAcceptedMentor}
+          onRequest={onMentoringRequest}
+          onCancel={onMentoringCancel}
+        />
       </td>
     </tr>
   );
@@ -172,9 +253,41 @@ export default function UserListPage() {
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useUserListInfiniteQuery();
+  const { toggleFollow, setMentoringStatus } = useUserListCacheUpdate();
 
   const allUsers = data?.pages.flatMap((p) => p.users) ?? [];
   const hasAcceptedMentor = data?.pages[0]?.hasAcceptedMentor ?? false;
+
+  async function handleFollowToggle(user: UserItem) {
+    toggleFollow(user.userId, !user.following);
+    try {
+      if (user.following) {
+        await unfollowUser(user.userId);
+      } else {
+        await followUser(user.userId);
+      }
+    } catch {
+      toggleFollow(user.userId, user.following);
+    }
+  }
+
+  async function handleMentoringRequest(user: UserItem) {
+    setMentoringStatus(user.userId, "PENDING", hasAcceptedMentor);
+    try {
+      await requestMentoring(user.userId);
+    } catch {
+      setMentoringStatus(user.userId, "NONE", hasAcceptedMentor);
+    }
+  }
+
+  async function handleMentoringCancel(user: UserItem) {
+    setMentoringStatus(user.userId, "NONE", false);
+    try {
+      await cancelMentoring(user.userId);
+    } catch {
+      setMentoringStatus(user.userId, "ACCEPTED", true);
+    }
+  }
 
   const filtered = allUsers
     .filter((u) => tab === "전체" || u.following)
@@ -249,11 +362,13 @@ export default function UserListPage() {
         <table className="w-full">
           <thead>
             <tr className="bg-gray-50 border-b border-gray-100">
-              <th className="text-left px-5 py-3 text-[12px] text-gray-400 font-medium">순위</th>
+              <th className="text-center px-5 py-3 text-[12px] text-gray-400 font-medium whitespace-nowrap w-16">순위</th>
               <th className="text-left px-2 py-3 text-[12px] text-gray-400 font-medium">투자자</th>
-              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">팔로워</th>
-              <th className="text-right px-3 py-3 text-[12px] text-gray-400 font-medium">팔로우</th>
-              <th className="text-right px-5 py-3 text-[12px] text-gray-400 font-medium">멘토신청</th>
+              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium whitespace-nowrap w-20">팔로워</th>
+              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium whitespace-nowrap w-24">총 수익률</th>
+              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium whitespace-nowrap w-28">총 수익</th>
+              <th className="text-center px-4 py-3 text-[12px] text-gray-400 font-medium whitespace-nowrap w-24">팔로우</th>
+              <th className="text-center px-4 py-3 text-[12px] text-gray-400 font-medium whitespace-nowrap w-24">멘토</th>
             </tr>
           </thead>
           <tbody>
@@ -268,6 +383,8 @@ export default function UserListPage() {
                       </div>
                     </td>
                     <td className="px-4 py-4"><div className="h-3 bg-gray-100 rounded-full w-10 ml-auto" /></td>
+                    <td className="px-4 py-4"><div className="h-3 bg-gray-100 rounded-full w-14 ml-auto" /></td>
+                    <td className="px-4 py-4"><div className="h-3 bg-gray-100 rounded-full w-16 ml-auto" /></td>
                     <td className="px-3 py-4"><div className="h-7 bg-gray-100 rounded-lg w-16 ml-auto" /></td>
                     <td className="px-5 py-4"><div className="h-7 bg-gray-100 rounded-lg w-18 ml-auto" /></td>
                   </tr>
@@ -278,6 +395,9 @@ export default function UserListPage() {
                     user={user}
                     rank={i + 1}
                     hasAcceptedMentor={hasAcceptedMentor}
+                    onFollowToggle={handleFollowToggle}
+                    onMentoringRequest={handleMentoringRequest}
+                    onMentoringCancel={handleMentoringCancel}
                   />
                 ))}
           </tbody>

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -10,6 +10,7 @@ import StockDetailPage from "@/pages/stocks/StockDetailPage";
 import ProtectedRoute from "./ProtectedRoute";
 import TradeDiaryPage from "@/pages/trade-diaries/TradeDiaryPage";
 import DiaryDetailPage from "@/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPage";
+import UserListPage from "@/pages/user-list/userListPage";
 
 export const router = createBrowserRouter([
   {
@@ -35,6 +36,7 @@ export const router = createBrowserRouter([
               { path: ":tradeDiaryId", element: <DiaryDetailPage /> },
             ],
           },
+          { path: "users", element: <UserListPage /> },
         ],
       },
     ],


### PR DESCRIPTION
 ## #️⃣  관련 이슈
  - closed #24                                                                                                       
                  
  ## 💡 작업 배경
  수익률 기준 투자자 랭킹 목록 페이지가 미구현 상태로,                                                          
  유저 목록 조회 및 팔로우/멘토신청 기능 구현이 필요했음.
                                                                                                                
  ## 🧩 작업 내용                                                                                               
  - 유저 랭킹 목록 조회 및 무한 스크롤 구현
  - 전체/팔로잉 탭 및 유저 검색 기능 구현                                                                       
  - 상위 3명 포디움 UI 구현                                                                                     
  - 팔로우/언팔로우 버튼 API 연동 및 낙관적 업데이트 적용
  - 멘토신청/신청완료/멘토 버튼 상태 관리 및 API 연동                                                           
  - 멘토가 있는 경우 다른 유저의 멘토신청 버튼 비활성화/숨김 처리                                               
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                         
<img width="1460" height="950" alt="image" src="https://github.com/user-attachments/assets/9e45d334-86fa-4c7f-a41d-6d86f4129a2a" />
                                                                                       
                                                                                                                
  ## 📝 기타 