### PR TITLE
[Feat] 매수/매도 주문 모달 및 API 연결

### DIFF
--- a/src/api/tradeApi.ts
+++ b/src/api/tradeApi.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { fetchClient } from "@/lib/fetchClient";
 import type { ApiResponse } from "./authApi";
 
@@ -17,6 +17,24 @@ export type TradeHistoryItem = {
   tradedAt: string;
 };
 
+export type OrderRequest = {
+  ticker: string;
+  orderType: "MARKET" | "LIMIT";
+  price: number;
+  quantity: number;
+  diary: string;
+};
+
+export type OrderResponse = {
+  orderId: number;
+  ticker: string;
+  orderType: string;
+  tradeType: string;
+  price: number;
+  quantity: number;
+  status: string;
+};
+
 // ─── Query Keys ───────────────────────────────────────────────────────────────
 
 export const tradeQueryKeys = {
@@ -24,6 +42,32 @@ export const tradeQueryKeys = {
 };
 
 // ─── Hooks ────────────────────────────────────────────────────────────────────
+
+export function useBuyOrderMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: OrderRequest) =>
+      fetchClient
+        .post<ApiResponse<OrderResponse>>("/api/trades/buy", body)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tradeQueryKeys.history });
+    },
+  });
+}
+
+export function useSellOrderMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: OrderRequest) =>
+      fetchClient
+        .post<ApiResponse<OrderResponse>>("/api/trades/sell", body)
+        .then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tradeQueryKeys.history });
+    },
+  });
+}
 
 export function useTradeHistoryQuery() {
   return useQuery({

--- a/src/components/stocks/TradeConfirmModal.tsx
+++ b/src/components/stocks/TradeConfirmModal.tsx
@@ -1,0 +1,87 @@
+import { AlertCircle } from "lucide-react";
+import Button from "@/components/ui/Button";
+import type { OrderSide } from "@/components/stocks/TradeOrderModal";
+
+type Props = {
+  side: OrderSide;
+  stockName: string;
+  orderType: "MARKET" | "LIMIT";
+  price: number;
+  quantity: number;
+  totalAmount: number;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+export default function TradeConfirmModal({
+  side,
+  stockName,
+  orderType,
+  price,
+  quantity,
+  totalAmount,
+  onClose,
+  onConfirm,
+}: Props) {
+  const isBuy = side === "buy";
+  const accent = {
+    text: isBuy ? "text-red-500" : "text-[#0046FF]",
+    bg: isBuy ? "bg-red-500 hover:bg-red-600" : "bg-[#0046FF] hover:bg-blue-700",
+    icon: isBuy ? "text-red-400" : "text-blue-400",
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative bg-white rounded-2xl p-5 w-full max-w-sm z-10 shadow-2xl text-center">
+        <AlertCircle size={32} className={`mx-auto mb-3 ${accent.icon}`} />
+        <h3 className="text-[16px] font-bold text-gray-900 mb-4">주문 확인</h3>
+
+        <div className="bg-gray-50 rounded-xl p-4 mb-5 text-left space-y-2">
+          <div className="flex justify-between text-[13px]">
+            <span className="text-gray-400">종목</span>
+            <span className="font-semibold text-gray-900">{stockName}</span>
+          </div>
+          <div className="flex justify-between text-[13px]">
+            <span className="text-gray-400">구분</span>
+            <span className={`font-semibold ${accent.text}`}>{isBuy ? "매수" : "매도"}</span>
+          </div>
+          <div className="flex justify-between text-[13px]">
+            <span className="text-gray-400">주문유형</span>
+            <span className="font-semibold text-gray-900">{orderType === "MARKET" ? "시장가" : "지정가"}</span>
+          </div>
+          <div className="flex justify-between text-[13px]">
+            <span className="text-gray-400">주문가격</span>
+            <span className="font-semibold text-gray-900">{price.toLocaleString()}원</span>
+          </div>
+          <div className="flex justify-between text-[13px]">
+            <span className="text-gray-400">수량</span>
+            <span className="font-semibold text-gray-900">{quantity}주</span>
+          </div>
+          <div className="flex justify-between text-[13px] pt-2 border-t border-gray-200">
+            <span className="text-gray-400">총 주문금액</span>
+            <span className={`font-bold text-[14px] ${accent.text}`}>{totalAmount.toLocaleString()}원</span>
+          </div>
+        </div>
+
+        <p className="text-[12px] text-gray-400 mb-4">매매일지가 함께 저장됩니다.</p>
+
+        <div className="flex gap-2">
+          <Button
+            variant="invalid"
+            className="flex-1 py-3 text-[13px] font-semibold cursor-pointer"
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            className={`flex-1 py-3 text-[13px] font-bold cursor-pointer ${accent.bg}`}
+            onClick={onConfirm}
+          >
+            {isBuy ? "매수" : "매도"} 확인
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/stocks/TradeOrderModal.tsx
+++ b/src/components/stocks/TradeOrderModal.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { X, AlertCircle } from "lucide-react";
+import Input from "@/components/ui/Input";
+import Button from "@/components/ui/Button";
+
+type OrderType = "MARKET" | "LIMIT";
+
+export type OrderSide = "buy" | "sell";
+
+type Props = {
+  side: OrderSide;
+  stockName: string;
+  currentPrice: number;
+  cash: number;
+  holdingQuantity: number;
+  onClose: () => void;
+  onConfirm: (params: {
+    orderType: OrderType;
+    price: number;
+    quantity: number;
+    diary: string;
+  }) => void;
+};
+
+export default function TradeOrderModal({
+  side,
+  stockName,
+  currentPrice,
+  cash,
+  holdingQuantity,
+  onClose,
+  onConfirm,
+}: Props) {
+  const isBuy = side === "buy";
+  const accent = {
+    text: isBuy ? "text-red-500" : "text-[#0046FF]",
+    bg: isBuy ? "bg-red-500 hover:bg-red-600" : "bg-[#0046FF] hover:bg-blue-700",
+    bgLight: isBuy ? "bg-red-50" : "bg-blue-50",
+  };
+
+  const [orderType, setOrderType] = useState<OrderType>("MARKET");
+  const [limitPrice, setLimitPrice] = useState("");
+  const [quantity, setQuantity] = useState("");
+  const [diary, setDiary] = useState("");
+
+  const execPrice = orderType === "MARKET" ? currentPrice : Number(limitPrice) || 0;
+  const qty = parseInt(quantity) || 0;
+  const totalAmount = execPrice * qty;
+
+  const maxQty = isBuy
+    ? Math.floor(cash / currentPrice)
+    : holdingQuantity;
+
+  const canSubmit = qty > 0 && diary.trim().length > 0 && (orderType === "MARKET" || execPrice > 0);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative bg-white rounded-2xl p-6 w-full max-w-md z-10 shadow-2xl max-h-[90vh] overflow-y-auto">
+
+        {/* 헤더 */}
+        <div className="flex items-center justify-between mb-5">
+          <div>
+            <h3 className="text-[18px] font-bold text-gray-900">
+              <span className={accent.text}>{isBuy ? "매수" : "매도"}</span>{" "}
+              {stockName}
+            </h3>
+            <p className="text-[13px] text-gray-400 mt-0.5">
+              현재가: {currentPrice.toLocaleString()}원
+            </p>
+          </div>
+          <button onClick={onClose} className="cursor-pointer">
+            <X size={20} className="text-gray-400" />
+          </button>
+        </div>
+
+        {/* 주문 가능금액 */}
+        <div className={`rounded-xl px-4 py-3 mb-4 ${accent.bgLight}`}>
+          <div className="flex justify-between items-center">
+            <span className="text-[12px] font-semibold text-gray-500">주문 가능금액</span>
+            <span className={`text-[13px] font-bold ${accent.text}`}>
+              {cash.toLocaleString()}원
+            </span>
+          </div>
+        </div>
+
+        {/* 시장가 / 지정가 */}
+        <div className="flex gap-2 mb-4">
+          {(["MARKET", "LIMIT"] as OrderType[]).map((t) => (
+            <Button
+              key={t}
+              onClick={() => setOrderType(t)}
+              className={`flex-1 py-2 text-[13px] cursor-pointer ${
+                orderType === t ? `${accent.bg} text-white` : "bg-gray-100 text-gray-500"
+              }`}
+            >
+              {t === "MARKET" ? "시장가" : "지정가"}
+            </Button>
+          ))}
+        </div>
+
+        {/* 가격 */}
+        <div className="mb-4">
+          <label className="text-[12px] font-semibold text-gray-500 mb-1.5 block">
+            주문가격
+          </label>
+          {orderType === "MARKET" ? (
+            <div className="w-full px-4 py-2.5 rounded-xl border border-gray-100 bg-gray-50 text-[13px] text-gray-500">
+              {currentPrice.toLocaleString()}원 (시장가)
+            </div>
+          ) : (
+            <Input
+              type="number"
+              value={limitPrice}
+              onChange={(e) => setLimitPrice(e.target.value)}
+              placeholder="가격을 입력하세요"
+            />
+          )}
+        </div>
+
+        {/* 수량 */}
+        <div className="mb-4">
+          <label className="text-[12px] font-semibold text-gray-500 mb-1.5 block">
+            수량 (주)
+          </label>
+          <Input
+            type="number"
+            value={quantity}
+            onChange={(e) => setQuantity(e.target.value)}
+            placeholder="0"
+            min="1"
+          />
+          <p className="text-[12px] text-gray-400 mt-1">
+            최대 {maxQty}주 {isBuy ? "매수" : "매도"} 가능
+          </p>
+        </div>
+
+        {/* 주문금액 */}
+        <div className="bg-gray-50 rounded-xl px-4 py-3 mb-4">
+          <div className="flex justify-between text-[13px]">
+            <span className="text-gray-500">주문금액</span>
+            <span className="font-bold text-gray-900">
+              {qty > 0 ? totalAmount.toLocaleString() : "-"}원
+            </span>
+          </div>
+        </div>
+
+        {/* 매매일지 */}
+        <div className="mb-5">
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="text-[13px] font-semibold text-gray-700">
+              매매일지 <span className="text-red-400">*</span>
+              <span className="text-[12px] font-normal text-gray-400 ml-1">(필수)</span>
+            </label>
+            <span className={`text-[12px] ${diary.length > 450 ? "text-red-400" : "text-gray-400"}`}>
+              {diary.length}/500
+            </span>
+          </div>
+          <textarea
+            value={diary}
+            onChange={(e) => e.target.value.length <= 500 && setDiary(e.target.value)}
+            placeholder="이 종목을 매수/매도한 이유, 전략, 목표가 등을 기록하세요."
+            rows={4}
+            className="w-full px-4 py-3 rounded-xl border border-gray-200 text-[13px] outline-none focus:border-[#0046FF] transition-colors resize-none leading-relaxed"
+          />
+          {!diary.trim() && qty > 0 && (
+            <p className="text-[12px] text-red-400 mt-1 flex items-center gap-1">
+              <AlertCircle size={11} />
+              매매일지를 작성해야 주문할 수 있습니다.
+            </p>
+          )}
+        </div>
+
+        {/* 버튼 */}
+        <div className="flex gap-2">
+          <Button
+            variant="invalid"
+            className="flex-1 py-3 text-[13px] font-semibold cursor-pointer"
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            disabled={!canSubmit}
+            className={`flex-1 py-3 text-[13px] font-bold cursor-pointer disabled:opacity-40 ${accent.bg}`}
+            onClick={() => onConfirm({ orderType, price: execPrice, quantity: qty, diary })}
+          >
+            {isBuy ? "매수하기" : "매도하기"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/stocks/TradeOrderModal.tsx
+++ b/src/components/stocks/TradeOrderModal.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { X, AlertCircle } from "lucide-react";
-import Input from "@/components/ui/Input";
 import Button from "@/components/ui/Button";
 
 type OrderType = "MARKET" | "LIMIT";
@@ -56,16 +55,16 @@ export default function TradeOrderModal({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className="relative bg-white rounded-2xl p-6 w-full max-w-md z-10 shadow-2xl max-h-[90vh] overflow-y-auto">
+      <div className="relative bg-white rounded-2xl p-4 w-full max-w-sm z-10 shadow-2xl">
 
         {/* 헤더 */}
-        <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center justify-between mb-3">
           <div>
-            <h3 className="text-[18px] font-bold text-gray-900">
+            <h3 className="text-[17px] font-bold text-gray-900">
               <span className={accent.text}>{isBuy ? "매수" : "매도"}</span>{" "}
               {stockName}
             </h3>
-            <p className="text-[13px] text-gray-400 mt-0.5">
+            <p className="text-[12px] text-gray-400 mt-0.5">
               현재가: {currentPrice.toLocaleString()}원
             </p>
           </div>
@@ -75,60 +74,62 @@ export default function TradeOrderModal({
         </div>
 
         {/* 주문 가능금액 */}
-        <div className={`rounded-xl px-4 py-3 mb-4 ${accent.bgLight}`}>
+        <div className={`rounded-xl px-3 py-2 mb-3 ${accent.bgLight}`}>
           <div className="flex justify-between items-center">
             <span className="text-[12px] font-semibold text-gray-500">주문 가능금액</span>
-            <span className={`text-[13px] font-bold ${accent.text}`}>
+            <span className={`text-[12px] font-bold ${accent.text}`}>
               {cash.toLocaleString()}원
             </span>
           </div>
         </div>
 
         {/* 시장가 / 지정가 */}
-        <div className="flex gap-2 mb-4">
+        <div className="flex bg-gray-100 rounded-xl p-1 mb-3">
           {(["MARKET", "LIMIT"] as OrderType[]).map((t) => (
-            <Button
+            <button
               key={t}
               onClick={() => setOrderType(t)}
-              className={`flex-1 py-2 text-[13px] cursor-pointer ${
-                orderType === t ? `${accent.bg} text-white` : "bg-gray-100 text-gray-500"
+              className={`flex-1 py-1.5 rounded-lg text-[13px] font-semibold transition-all cursor-pointer ${
+                orderType === t ? "bg-white text-[#0046FF] shadow-sm" : "text-gray-400"
               }`}
             >
               {t === "MARKET" ? "시장가" : "지정가"}
-            </Button>
+            </button>
           ))}
         </div>
 
         {/* 가격 */}
-        <div className="mb-4">
-          <label className="text-[12px] font-semibold text-gray-500 mb-1.5 block">
+        <div className="mb-3">
+          <label className="text-[12px] font-semibold text-gray-500 mb-1 block">
             주문가격
           </label>
           {orderType === "MARKET" ? (
-            <div className="w-full px-4 py-2.5 rounded-xl border border-gray-100 bg-gray-50 text-[13px] text-gray-500">
+            <div className="w-full px-4 py-2 rounded-xl border border-gray-100 bg-gray-50 text-[13px] text-gray-500">
               {currentPrice.toLocaleString()}원 (시장가)
             </div>
           ) : (
-            <Input
+            <input
               type="number"
               value={limitPrice}
               onChange={(e) => setLimitPrice(e.target.value)}
               placeholder="가격을 입력하세요"
+              className="w-full px-4 py-2 rounded-xl border border-gray-200 text-[13px] text-gray-900 placeholder:text-gray-400 outline-none focus:border-[#0046FF] transition-colors"
             />
           )}
         </div>
 
         {/* 수량 */}
-        <div className="mb-4">
-          <label className="text-[12px] font-semibold text-gray-500 mb-1.5 block">
+        <div className="mb-3">
+          <label className="text-[12px] font-semibold text-gray-500 mb-1 block">
             수량 (주)
           </label>
-          <Input
+          <input
             type="number"
             value={quantity}
             onChange={(e) => setQuantity(e.target.value)}
             placeholder="0"
             min="1"
+            className="w-full px-4 py-2 rounded-xl border border-gray-200 text-[13px] text-gray-900 placeholder:text-gray-400 outline-none focus:border-[#0046FF] transition-colors"
           />
           <p className="text-[12px] text-gray-400 mt-1">
             최대 {maxQty}주 {isBuy ? "매수" : "매도"} 가능
@@ -136,7 +137,7 @@ export default function TradeOrderModal({
         </div>
 
         {/* 주문금액 */}
-        <div className="bg-gray-50 rounded-xl px-4 py-3 mb-4">
+        <div className="bg-gray-50 rounded-xl px-3 py-2 mb-3">
           <div className="flex justify-between text-[13px]">
             <span className="text-gray-500">주문금액</span>
             <span className="font-bold text-gray-900">
@@ -146,8 +147,8 @@ export default function TradeOrderModal({
         </div>
 
         {/* 매매일지 */}
-        <div className="mb-5">
-          <div className="flex items-center justify-between mb-1.5">
+        <div className="mb-3">
+          <div className="flex items-center justify-between mb-1">
             <label className="text-[13px] font-semibold text-gray-700">
               매매일지 <span className="text-red-400">*</span>
               <span className="text-[12px] font-normal text-gray-400 ml-1">(필수)</span>
@@ -160,8 +161,8 @@ export default function TradeOrderModal({
             value={diary}
             onChange={(e) => e.target.value.length <= 500 && setDiary(e.target.value)}
             placeholder="이 종목을 매수/매도한 이유, 전략, 목표가 등을 기록하세요."
-            rows={4}
-            className="w-full px-4 py-3 rounded-xl border border-gray-200 text-[13px] outline-none focus:border-[#0046FF] transition-colors resize-none leading-relaxed"
+            rows={3}
+            className="w-full px-4 py-2.5 rounded-xl border border-gray-200 text-[13px] outline-none focus:border-[#0046FF] transition-colors resize-none leading-relaxed"
           />
           {!diary.trim() && qty > 0 && (
             <p className="text-[12px] text-red-400 mt-1 flex items-center gap-1">

--- a/src/pages/stocks/StockDetailPage.tsx
+++ b/src/pages/stocks/StockDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   useOrderBookQuery,
   stockQueryKeys,
 } from "@/api/stockApi";
+import { useBuyOrderMutation, useSellOrderMutation } from "@/api/tradeApi";
 import type { StockQuote, StockItemMessage, OrderBookData } from "@/api/stockApi";
 import { useStockStore } from "@/store/stockStore";
 import StockDetailHeader from "@/components/stocks/StockDetailHeader";
@@ -39,6 +40,9 @@ export default function StockDetailPage() {
 
   const [orderSide, setOrderSide] = useState<OrderSide | null>(null);
   const [pendingOrder, setPendingOrder] = useState<PendingOrder | null>(null);
+
+  const buyMutation = useBuyOrderMutation();
+  const sellMutation = useSellOrderMutation();
 
   const { data: quote, isLoading } = useStockQuoteQuery(stockCode);
   const { data: holding } = useStockHoldingQuery(stockCode);
@@ -185,8 +189,22 @@ export default function StockDetailPage() {
         totalAmount={pendingOrder.price * pendingOrder.quantity}
         onClose={() => setPendingOrder(null)}
         onConfirm={() => {
-          // TODO: API 호출
-          setPendingOrder(null);
+          if (!pendingOrder) return;
+          const body = {
+            ticker: stockCode,
+            orderType: pendingOrder.orderType,
+            price: pendingOrder.price,
+            quantity: pendingOrder.quantity,
+            diary: pendingOrder.diary,
+          };
+          const mutation = pendingOrder.side === "buy" ? buyMutation : sellMutation;
+          mutation.mutate(body, {
+            onSuccess: () => {
+              queryClient.invalidateQueries({ queryKey: stockQueryKeys.holding(stockCode) });
+              queryClient.invalidateQueries({ queryKey: stockQueryKeys.cash });
+              setPendingOrder(null);
+            },
+          });
         }}
       />
     )}

--- a/src/pages/stocks/StockDetailPage.tsx
+++ b/src/pages/stocks/StockDetailPage.tsx
@@ -21,6 +21,15 @@ import HoldingStatus from "@/components/stocks/HoldingStatus";
 import OrderBook from "@/components/stocks/OrderBook";
 import TradeOrderModal from "@/components/stocks/TradeOrderModal";
 import type { OrderSide } from "@/components/stocks/TradeOrderModal";
+import TradeConfirmModal from "@/components/stocks/TradeConfirmModal";
+
+type PendingOrder = {
+  side: OrderSide;
+  orderType: "MARKET" | "LIMIT";
+  price: number;
+  quantity: number;
+  diary: string;
+};
 
 export default function StockDetailPage() {
   const { stockCode = "" } = useParams<{ stockCode: string }>();
@@ -29,6 +38,7 @@ export default function StockDetailPage() {
   const selectedStock = useStockStore((s) => s.selectedStock);
 
   const [orderSide, setOrderSide] = useState<OrderSide | null>(null);
+  const [pendingOrder, setPendingOrder] = useState<PendingOrder | null>(null);
 
   const { data: quote, isLoading } = useStockQuoteQuery(stockCode);
   const { data: holding } = useStockHoldingQuery(stockCode);
@@ -158,7 +168,26 @@ export default function StockDetailPage() {
         cash={cash ?? 0}
         holdingQuantity={holding?.holdingQuantity ?? 0}
         onClose={() => setOrderSide(null)}
-        onConfirm={() => setOrderSide(null)}
+        onConfirm={(params) => {
+          setPendingOrder({ ...params, side: orderSide! });
+          setOrderSide(null);
+        }}
+      />
+    )}
+
+    {pendingOrder && (
+      <TradeConfirmModal
+        side={pendingOrder.side}
+        stockName={quote?.stockName ?? ""}
+        orderType={pendingOrder.orderType}
+        price={pendingOrder.price}
+        quantity={pendingOrder.quantity}
+        totalAmount={pendingOrder.price * pendingOrder.quantity}
+        onClose={() => setPendingOrder(null)}
+        onConfirm={() => {
+          // TODO: API 호출
+          setPendingOrder(null);
+        }}
       />
     )}
     </>

--- a/src/pages/stocks/StockDetailPage.tsx
+++ b/src/pages/stocks/StockDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
 import { Client } from "@stomp/stompjs";
@@ -19,12 +19,16 @@ import StockInfoGrid from "@/components/stocks/StockInfoGrid";
 import TradeHistory from "@/components/stocks/TradeHistory";
 import HoldingStatus from "@/components/stocks/HoldingStatus";
 import OrderBook from "@/components/stocks/OrderBook";
+import TradeOrderModal from "@/components/stocks/TradeOrderModal";
+import type { OrderSide } from "@/components/stocks/TradeOrderModal";
 
 export default function StockDetailPage() {
   const { stockCode = "" } = useParams<{ stockCode: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const selectedStock = useStockStore((s) => s.selectedStock);
+
+  const [orderSide, setOrderSide] = useState<OrderSide | null>(null);
 
   const { data: quote, isLoading } = useStockQuoteQuery(stockCode);
   const { data: holding } = useStockHoldingQuery(stockCode);
@@ -113,6 +117,7 @@ export default function StockDetailPage() {
   };
 
   return (
+    <>
     <div className="flex flex-col p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
       <StockDetailHeader stock={headerStock} />
 
@@ -137,12 +142,25 @@ export default function StockDetailPage() {
           <HoldingStatus
             holding={holding}
             cash={cash}
-            onBuy={() => navigate(`/invest/${stockCode}/buy`)}
-            onSell={() => navigate(`/invest/${stockCode}/sell`)}
+            onBuy={() => setOrderSide("buy")}
+            onSell={() => setOrderSide("sell")}
           />
           {orderBook && <OrderBook orderBook={orderBook} />}
         </div>
       </div>
     </div>
+
+    {orderSide && (
+      <TradeOrderModal
+        side={orderSide}
+        stockName={quote.stockName}
+        currentPrice={quote.currentPrice}
+        cash={cash ?? 0}
+        holdingQuantity={holding?.holdingQuantity ?? 0}
+        onClose={() => setOrderSide(null)}
+        onConfirm={() => setOrderSide(null)}
+      />
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #7

## 💡 작업 배경
  - 매수/매도 주문 입력 모달(TradeOrderModal) 컴포넌트 구현
  - 주문 확인 모달(TradeConfirmModal) 컴포넌트 구현
  - StockDetailPage에서 매수/매도 버튼 클릭 시 모달 2단계 플로우 연결
  - tradeApi.ts에 useBuyOrderMutation, useSellOrderMutation 추가 및 API 연결

## 🧩 작업 내용
 - TradeOrderModal: 시장가/지정가 선택, 수량 입력, 매매일지 작성(필수) 포함
 - TradeConfirmModal: 주문 정보 요약 후 최종 확인
 - 주문 성공 시 보유 수량 및 예수금 자동 갱신 (invalidateQueries)
 - URL 변경 없이 모달로만 처리 (orderSide, pendingOrder 상태 관리)

  매수/매도 버튼 클릭
    → TradeOrderModal (주문 입력)
    → TradeConfirmModal (최종 확인)
    → POST /api/trades/buy or /api/trades/sell
    → 보유수량 & 예수금 갱신
 

## 📸 스크린샷(선택)
<img width="551" height="742" alt="image" src="https://github.com/user-attachments/assets/a48f6dcb-5f7d-40c0-8eb3-88b7735ad46a" />
