### PR TITLE
[Feat] 매매일지 댓글 기능 추가

### DIFF
--- a/src/api/tradeDiaryApi.ts
+++ b/src/api/tradeDiaryApi.ts
@@ -79,3 +79,30 @@ export function usePostCommentMutation(diaryId: string) {
     },
   });
 }
+
+
+export function useModifyCommentMutation(diaryId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ commentId, content }: { commentId: number; content: string }) =>
+      fetchClient.patch(`/api/comments/${commentId}`, { content }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: myDiariesQueryKeys.diaryDetail(diaryId),
+      });
+    },
+  });
+}
+
+export function useDeleteCommentMutation(diaryId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (commentId: number) =>
+      fetchClient.delete(`/api/comments/${commentId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: myDiariesQueryKeys.diaryDetail(diaryId),
+      });
+    },
+  });
+}

--- a/src/pages/stocks/[stockId]/StockDetailPage.tsx
+++ b/src/pages/stocks/[stockId]/StockDetailPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/api/stockApi";
 import { useBuyOrderMutation, useSellOrderMutation } from "@/api/tradeApi";
 import type { StockQuote, StockItemMessage, OrderBookData } from "@/api/stockApi";
+
 import { useStockStore } from "@/store/stockStore";
 import StockDetailHeader from "@/components/stocks/StockDetailHeader";
 import StockInfoGrid from "@/components/stocks/StockInfoGrid";

--- a/src/pages/trade-diaries/TradeDiaryPage.tsx
+++ b/src/pages/trade-diaries/TradeDiaryPage.tsx
@@ -13,7 +13,6 @@ function MyDiariesRow({
   onClick: () => void;
 }) {
   const isBuy = myDiaries.tradeType === "BUY";
-  const hasProfit = myDiaries.profit !== 0;
   const isPositive = myDiaries.profit > 0;
 
   return (
@@ -43,14 +42,15 @@ function MyDiariesRow({
             {myDiaries.createdAt.slice(0, 10).replace(/-/g, ".")}
           </span>
         </div>
-        {hasProfit && (
+        {!isBuy && (
           <span
             className={`text-[14px] font-semibold ${
               isPositive ? "text-[#FF4444]" : "text-[#0046FF]"
             }`}
           >
-            {isPositive ? "+" : ""}
-            {myDiaries.profit?.toLocaleString()}원
+            {isPositive
+              ? `+${myDiaries.profit?.toLocaleString()}원`
+              : ` ${myDiaries.profit?.toLocaleString()}원`}
           </span>
         )}
       </div>
@@ -92,43 +92,44 @@ export default function TradeDiaryPage() {
     .slice();
 
   return (
-    <div className="flex flex-col h-full p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
-      {/* 헤더 */}
-      <div>
+    <div className="flex flex-col h-screen bg-gray-50">
+      {/* 헤더 + 검색 (고정) */}
+      <div className="flex flex-col gap-5 p-6 pb-4 shrink-0">
         <h1 className="text-[22px] font-bold text-gray-900">매매일지</h1>
-      </div>
-      {/* 검색 + 정렬 */}
-      <div className="flex items-center gap-3">
-        <div className="relative flex-1 max-w-xs">
-          <Search
-            size={15}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
-          />
-          <input
-            type="text"
-            placeholder="종목명으로 검색"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="w-full pl-9 pr-4 py-2 text-[13px] bg-white border border-gray-200 rounded-xl outline-none focus:border-[#0046FF] transition-colors"
-          />
+        <div className="flex items-center gap-3">
+          <div className="relative flex-1 max-w-xs">
+            <Search
+              size={15}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            />
+            <input
+              type="text"
+              placeholder="종목명으로 검색"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full pl-9 pr-4 py-2 text-[13px] bg-white border border-gray-200 rounded-xl outline-none focus:border-[#0046FF] transition-colors"
+            />
+          </div>
         </div>
       </div>
 
-      {/* 매매일지 리스트 */}
-      <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
-        {filtered.length > 0 ? (
-          filtered.map((item) => (
-            <MyDiariesRow
-              key={item.diaryId}
-              myDiaries={item}
-              onClick={() => navigate(`/trade-diary/${item.diaryId}`)}
-            />
-          ))
-        ) : (
-          <div className="text-center py-12 text-[14px] text-gray-400">
-            검색 결과가 없습니다.
-          </div>
-        )}
+      {/* 매매일지 리스트 (스크롤) */}
+      <div className="flex-1 overflow-y-auto px-6 pb-6">
+        <div className="bg-white rounded-2xl border border-gray-100 overflow-y-scroll h-full">
+          {filtered.length > 0 ? (
+            filtered.map((item) => (
+              <MyDiariesRow
+                key={item.diaryId}
+                myDiaries={item}
+                onClick={() => navigate(`/trade-diary/${item.diaryId}`)}
+              />
+            ))
+          ) : (
+            <div className="text-center py-12 text-[14px] text-gray-400">
+              검색 결과가 없습니다.
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPage.tsx
+++ b/src/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPage.tsx
@@ -1,15 +1,15 @@
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { ChevronLeft, Pencil } from "lucide-react";
-import { useDiaryDetailQuery, usePostCommentMutation } from "@/api/tradeDiaryApi";
+import {
+  useDiaryDetailQuery,
+  usePostCommentMutation,
+  useModifyCommentMutation,
+  useDeleteCommentMutation,
+} from "@/api/tradeDiaryApi";
 import Button from "@/components/ui/Button";
 import { useUser } from "@/store/authStore";
-
-function formatProfit(profit: number) {
-  const manwon = profit / 10000;
-  const sign = manwon >= 0 ? "+" : "";
-  return `${sign}${manwon % 1 === 0 ? manwon : manwon.toFixed(1)}만원`;
-}
+import Badge from "@/components/ui/Badge";
 
 function formatProfitRate(rate: number) {
   const sign = rate >= 0 ? "+" : "";
@@ -40,15 +40,19 @@ export default function DiaryDetailPage() {
     isError,
   } = useDiaryDetailQuery(tradeDiaryId ?? "");
   const [commentInput, setCommentInput] = useState("");
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const [editInput, setEditInput] = useState("");
   const user = useUser();
-  const { mutate: postComment, isPending } = usePostCommentMutation(tradeDiaryId ?? "");
+  const diaryId = tradeDiaryId ?? "";
+  const { mutate: postComment, isPending } = usePostCommentMutation(diaryId);
+  const { mutate: modifyComment } = useModifyCommentMutation(diaryId);
+  const { mutate: deleteComment } = useDeleteCommentMutation(diaryId);
 
   const isProfit = (diary?.profit ?? 0) >= 0;
   const profitColor = isProfit ? "text-[#FF4444]" : "text-[#0046FF]";
   const tradeTypeLabel = diary?.tradeType === "BUY" ? "매수" : "매도";
   const tradeTypeBg =
     diary?.tradeType === "BUY" ? "bg-[#FF4444]" : "bg-[#0046FF]";
-
   return (
     <div className="flex flex-col h-full p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
       {/* 헤더 */}
@@ -58,7 +62,7 @@ export default function DiaryDetailPage() {
             onClick={() => navigate("/trade-diary")}
             className="text-gray-500 hover:text-gray-800 cursor-pointer"
           >
-            <ChevronLeft size={20}/>
+            <ChevronLeft size={20} />
           </button>
           <span className="text-gray-400 text-[14px]">매매일지</span>
           <span className="text-gray-300 text-[14px]">›</span>
@@ -100,11 +104,14 @@ export default function DiaryDetailPage() {
                   {diary.tickerCode}
                 </span>
               </div>
-              <div className="text-right">
-                <p className={`text-[16px] font-bold ${profitColor}`}>
-                  {formatProfit(diary.profit)}
-                </p>
-              </div>
+              {diary?.tradeType === "SELL" && (
+                <div className="text-right">
+                  <p className={`text-[16px] font-bold ${profitColor}`}>
+                    {isProfit ? "+" : ""}
+                    {diary.profit.toLocaleString()} 원
+                  </p>
+                </div>
+              )}
             </div>
 
             {/* 체결 요약 */}
@@ -169,32 +176,67 @@ export default function DiaryDetailPage() {
                       {comment.nickname}
                     </span>
                     {comment.isMentor && (
-                      <span className="px-1.5 py-0.5 text-[10px] font-semibold text-white bg-[#0046FF] rounded">
-                        멘토
+                      <span className="px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                        <Badge name="멘토" color="#FF9900" />
                       </span>
                     )}
                   </div>
-                  <div className="flex items-center gap-1">
-                    <Button variant="basic" className="text-[11px] px-2 py-0.5">
-                      수정
-                    </Button>
-                    {user?.nickname === comment.nickname ? (
+                  {user?.nickname === comment.nickname && (
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="basic"
+                        className="text-[11px] px-2 py-0.5"
+                        onClick={() => {
+                          setEditingCommentId(comment.commentId);
+                          setEditInput(comment.content);
+                        }}
+                      >
+                        수정
+                      </Button>
                       <Button
                         variant="basic"
                         className="text-[11px] px-2 py-0.5 border-red-500! text-red-500! hover:bg-red-50!"
+                        onClick={() => deleteComment(comment.commentId)}
                       >
                         삭제
                       </Button>
-                    ) : (
-                      <Button variant="invalid" className="text-[11px] px-2 py-0.5">
-                        삭제
-                      </Button>
-                    )}
-                  </div>
+                    </div>
+                  )}
                 </div>
-                <p className="text-[13px] text-gray-700 leading-relaxed">
-                  {comment.content}
-                </p>
+                {editingCommentId === comment.commentId ? (
+                  <div className="flex items-center gap-2 mt-1">
+                    <input
+                      type="text"
+                      value={editInput}
+                      onChange={(e) => setEditInput(e.target.value)}
+                      className="flex-1 px-3 py-1.5 text-[13px] bg-gray-50 border border-gray-200 rounded-xl outline-none focus:border-[#0046FF] transition-colors"
+                    />
+                    <Button
+                      variant="basic"
+                      className="text-[12px] px-2 py-0.5"
+                      onClick={() => {
+                        if (!editInput.trim()) return;
+                        modifyComment(
+                          { commentId: comment.commentId, content: editInput },
+                          { onSuccess: () => setEditingCommentId(null) },
+                        );
+                      }}
+                    >
+                      저장
+                    </Button>
+                    <Button
+                      variant="basic"
+                      className="text-[12px] px-2 py-0.5"
+                      onClick={() => setEditingCommentId(null)}
+                    >
+                      취소
+                    </Button>
+                  </div>
+                ) : (
+                  <p className="text-[12px] text-gray-700 leading-relaxed">
+                    {comment.content}
+                  </p>
+                )}
               </div>
             </div>
           ))}
@@ -216,7 +258,9 @@ export default function DiaryDetailPage() {
             disabled={isPending}
             onClick={() => {
               if (!commentInput.trim()) return;
-              postComment(commentInput, { onSuccess: () => setCommentInput("") });
+              postComment(commentInput, {
+                onSuccess: () => setCommentInput(""),
+              });
             }}
             className="px-4 py-2 text-[14px] font-semibold text-white bg-[#0046FF] rounded-xl hover:bg-blue-700 transition-colors disabled:opacity-50"
           >

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -5,7 +5,7 @@ import LoginPage from "@/pages/auth/LoginPage";
 import SignUpPage from "@/pages/auth/SignUpPage";
 import OAuthCallbackPage from "@/pages/auth/OauthCallbackPage";
 import StockList from "@/pages/stocks/StockList";
-import StockDetailPage from "@/pages/stocks/StockDetailPage";
+import StockDetailPage from "@/pages/stocks/[stockId]/StockDetailPage";
 import ProtectedRoute from "./ProtectedRoute";
 import TradeDiaryPage from "@/pages/trade-diaries/TradeDiaryPage";
 import DiaryDetailPage from "@/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPage";


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #20 

## 💡 작업 배경
매매일지 내 댓글 CRUD 기능 추가

## 🧩 작업 내용
1. API 함수 추가 — [tradeDiaryApi.ts](vscode-webview://0c07snjn3t9udtlqu8k6e3c2ij77ji1da3err4q9154a21apbo74/src/api/tradeDiaryApi.ts)
useModifyCommentMutation(diaryId)

PATCH /api/comments/{commentId} 호출
{ commentId, content } 를 받아 댓글 수정
성공 시 해당 일지 상세 쿼리 캐시 무효화
useDeleteCommentMutation(diaryId)

DELETE /api/comments/{commentId} 호출
commentId 를 받아 댓글 삭제
성공 시 해당 일지 상세 쿼리 캐시 무효화

2. UI 연결 — [DiaryDetailPage.tsx](vscode-webview://0c07snjn3t9udtlqu8k6e3c2ij77ji1da3err4q9154a21apbo74/src/pages/trade-diaries/%5BtradeDiaryId%5D/DiaryDetailPage.tsx)
수정 기능

본인 댓글에만 수정 버튼 표시 (user?.nickname === comment.nickname)
수정 버튼 클릭 → 댓글 자리에 인라인 입력창 + 저장/취소 버튼 표시
저장 클릭 → modifyComment 호출, 성공 시 편집 모드 종료
삭제 기능

본인 댓글에만 삭제 버튼 표시
삭제 클릭 → deleteComment 즉시 호출

상태 관리

editingCommentId — 현재 수정 중인 댓글 ID
editInput — 수정 입력값

## 📸 스크린샷(선택)
<img width="780" height="456" alt="image" src="https://github.com/user-attachments/assets/369d74fa-5968-4b25-aa98-51d7022325cf" />


## 📝 기타