### PR TITLE
[Feat] 내 프로필 화면 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.6",
     "chart.js": "^4.5.1",
+    "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.1",
@@ -22,6 +23,7 @@
     "react-hook-form": "^7.71.2",
     "react-router-dom": "^7.13.1",
     "sockjs-client": "^1.6.1",
+    "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -44,6 +47,9 @@ importers:
       sockjs-client:
         specifier: ^1.6.1
         version: 1.6.1
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -903,6 +909,10 @@ packages:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1565,6 +1575,9 @@ packages:
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
@@ -2458,6 +2471,8 @@ snapshots:
     dependencies:
       '@kurkle/color': 0.3.4
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3051,6 +3066,8 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.1: {}
 

--- a/src/api/tradeApi.ts
+++ b/src/api/tradeApi.ts
@@ -5,6 +5,7 @@ import type { ApiResponse } from "./authApi";
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type TradeHistoryItem = {
+  tickerCode: string;
   stockName: string;
   stockLogo: string;
   tradeType: "BUY" | "SELL";

--- a/src/api/userListApi.ts
+++ b/src/api/userListApi.ts
@@ -1,5 +1,5 @@
 import { fetchClient } from "@/lib/fetchClient";
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiResponse } from "./authApi";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -99,6 +99,36 @@ export function useUserListCacheUpdate() {
   }
 
   return { toggleFollow, setMentoringStatus };
+}
+
+// ─── Follow List Types ────────────────────────────────────────────────────────
+
+export type FollowUser = {
+  userId: number;
+  nickname: string;
+  imageUrl: string;
+};
+
+// ─── Follow List Hooks ────────────────────────────────────────────────────────
+
+export function useFollowersQuery() {
+  return useQuery({
+    queryKey: ["follows", "followers"],
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<FollowUser[]>>("/api/follows/followers")
+        .then((res) => res.data),
+  });
+}
+
+export function useFollowingQuery() {
+  return useQuery({
+    queryKey: ["follows", "following"],
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<FollowUser[]>>("/api/follows/following")
+        .then((res) => res.data),
+  });
 }
 
 // ─── React Query Hook ─────────────────────────────────────────────────────────

--- a/src/components/account/HoldingList.tsx
+++ b/src/components/account/HoldingList.tsx
@@ -70,7 +70,7 @@ export default function HoldingList({
               <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>수량</th>
               {showAvgPrice && <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>평균단가</th>}
               <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>현재가</th>
-              <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>평가액</th>
+              <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>평가금액</th>
               <th className={`text-right ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 font-medium`}>수익률</th>
             </tr>
           </thead>

--- a/src/components/account/HoldingList.tsx
+++ b/src/components/account/HoldingList.tsx
@@ -31,6 +31,7 @@ export default function HoldingList({
   hasMore = false,
   onLoadMore,
   isLoading = false,
+  showAvgPrice = true,
 }: Props) {
   const sentinelRef = useRef<HTMLTableRowElement>(null);
 

--- a/src/components/account/HoldingList.tsx
+++ b/src/components/account/HoldingList.tsx
@@ -64,7 +64,7 @@ export default function HoldingList({
             <tr className="bg-gray-50 border-b border-gray-100">
               <th className="text-left px-6 py-3 text-[12px] text-gray-400 font-medium">종목</th>
               <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">수량</th>
-              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">평균단가</th>
+              {showAvgPrice && <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">평균단가</th>}
               <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">현재가</th>
               <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">평가액</th>
               <th className="text-right px-6 py-3 text-[12px] text-gray-400 font-medium">수익률</th>
@@ -87,9 +87,11 @@ export default function HoldingList({
                   <td className="px-4 py-3.5 text-right text-[14px] font-semibold text-gray-900 tabular-nums">
                     {item.quantity}주
                   </td>
-                  <td className="px-4 py-3.5 text-right text-[13px] text-gray-500 tabular-nums">
-                    {item.averageBuyPrice.toLocaleString()}원
-                  </td>
+                  {showAvgPrice && (
+                    <td className="px-4 py-3.5 text-right text-[13px] text-gray-500 tabular-nums">
+                      {item.averageBuyPrice.toLocaleString()}원
+                    </td>
+                  )}
                   <td className="px-4 py-3.5 text-right text-[14px] font-semibold text-gray-900 tabular-nums">
                     {item.currentPrice.toLocaleString()}원
                   </td>

--- a/src/components/account/HoldingList.tsx
+++ b/src/components/account/HoldingList.tsx
@@ -20,6 +20,7 @@ type Props = {
   onLoadMore?: () => void;
   isLoading?: boolean;
   showAvgPrice?: boolean;
+  compact?: boolean;
 };
 
 function fmt(n: number) {
@@ -33,6 +34,7 @@ export default function HoldingList({
   onLoadMore,
   isLoading = false,
   showAvgPrice = true,
+  compact = false,
 }: Props) {
   const navigate = useNavigate();
   const sentinelRef = useRef<HTMLTableRowElement>(null);
@@ -64,12 +66,12 @@ export default function HoldingList({
         <table className="w-full">
           <thead className="sticky top-0 z-10">
             <tr className="bg-gray-50 border-b border-gray-100">
-              <th className="text-left px-6 py-3 text-[12px] text-gray-400 font-medium">종목</th>
-              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">수량</th>
-              {showAvgPrice && <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">평균단가</th>}
-              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">현재가</th>
-              <th className="text-right px-4 py-3 text-[12px] text-gray-400 font-medium">평가액</th>
-              <th className="text-right px-6 py-3 text-[12px] text-gray-400 font-medium">수익률</th>
+              <th className={`text-left ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 font-medium`}>종목</th>
+              <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>수량</th>
+              {showAvgPrice && <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>평균단가</th>}
+              <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>현재가</th>
+              <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>평가액</th>
+              <th className={`text-right ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 font-medium`}>수익률</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50">
@@ -77,34 +79,34 @@ export default function HoldingList({
               const isPositive = item.profitRate >= 0;
               return (
                 <tr key={item.tickerCode} className="hover:bg-gray-50/50 transition-colors cursor-pointer" onClick={() => navigate(`/invest/${item.tickerCode}`)}>
-                  <td className="px-6 py-3.5">
-                    <div className="flex items-center gap-3">
-                      <Avatar name={item.stockName} src={item.stockLogo} size={34} />
+                  <td className={compact ? "px-3 py-2" : "px-6 py-3.5"}>
+                    <div className="flex items-center gap-2">
+                      <Avatar name={item.stockName} src={item.stockLogo} size={compact ? 26 : 34} />
                       <div>
-                        <p className="text-[14px] font-semibold text-gray-900">{item.stockName}</p>
-                        <p className="text-[11px] text-gray-400">{item.tickerCode}</p>
+                        <p className={`${compact ? "text-[12px]" : "text-[14px]"} font-semibold text-gray-900`}>{item.stockName}</p>
+                        <p className="text-[10px] text-gray-400">{item.tickerCode}</p>
                       </div>
                     </div>
                   </td>
-                  <td className="px-4 py-3.5 text-right text-[14px] font-semibold text-gray-900 tabular-nums">
+                  <td className={`${compact ? "px-2 py-2" : "px-4 py-3.5"} text-right ${compact ? "text-[11px]" : "text-[14px]"} font-semibold text-gray-900 tabular-nums`}>
                     {item.quantity}주
                   </td>
                   {showAvgPrice && (
-                    <td className="px-4 py-3.5 text-right text-[13px] text-gray-500 tabular-nums">
+                    <td className={`${compact ? "px-2 py-2" : "px-4 py-3.5"} text-right ${compact ? "text-[11px]" : "text-[13px]"} text-gray-500 tabular-nums`}>
                       {item.averageBuyPrice.toLocaleString()}원
                     </td>
                   )}
-                  <td className="px-4 py-3.5 text-right text-[14px] font-semibold text-gray-900 tabular-nums">
+                  <td className={`${compact ? "px-2 py-2" : "px-4 py-3.5"} text-right ${compact ? "text-[11px]" : "text-[14px]"} font-semibold text-gray-900 tabular-nums`}>
                     {item.currentPrice.toLocaleString()}원
                   </td>
-                  <td className="px-4 py-3.5 text-right text-[14px] font-semibold text-gray-900 tabular-nums">
+                  <td className={`${compact ? "px-2 py-2" : "px-4 py-3.5"} text-right ${compact ? "text-[11px]" : "text-[14px]"} font-semibold text-gray-900 tabular-nums`}>
                     {fmt(item.evaluationAmount)}
                   </td>
-                  <td className="px-6 py-3.5 text-right">
-                    <p className={`text-[13px] font-semibold tabular-nums ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+                  <td className={compact ? "px-3 py-2 text-right" : "px-6 py-3.5 text-right"}>
+                    <p className={`${compact ? "text-[11px]" : "text-[13px]"} font-semibold tabular-nums ${isPositive ? "text-red-500" : "text-blue-500"}`}>
                       {isPositive ? "+" : ""}{item.profitRate.toFixed(2)}%
                     </p>
-                    <p className={`text-[11px] font-medium tabular-nums ${isPositive ? "text-red-400" : "text-blue-400"}`}>
+                    <p className={`${compact ? "text-[10px]" : "text-[11px]"} font-medium tabular-nums ${isPositive ? "text-red-400" : "text-blue-400"}`}>
                       {isPositive ? "+" : ""}{fmt(item.profitAmount)}
                     </p>
                   </td>

--- a/src/components/account/HoldingList.tsx
+++ b/src/components/account/HoldingList.tsx
@@ -18,6 +18,7 @@ type Props = {
   hasMore?: boolean;
   onLoadMore?: () => void;
   isLoading?: boolean;
+  showAvgPrice?: boolean;
 };
 
 function fmt(n: number) {

--- a/src/components/account/HoldingList.tsx
+++ b/src/components/account/HoldingList.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import Avatar from "@/components/ui/Avatar";
 
 export type HoldingItem = {
@@ -33,6 +34,7 @@ export default function HoldingList({
   isLoading = false,
   showAvgPrice = true,
 }: Props) {
+  const navigate = useNavigate();
   const sentinelRef = useRef<HTMLTableRowElement>(null);
 
   useEffect(() => {
@@ -74,7 +76,7 @@ export default function HoldingList({
             {items.map((item) => {
               const isPositive = item.profitRate >= 0;
               return (
-                <tr key={item.tickerCode} className="hover:bg-gray-50/50 transition-colors">
+                <tr key={item.tickerCode} className="hover:bg-gray-50/50 transition-colors cursor-pointer" onClick={() => navigate(`/invest/${item.tickerCode}`)}>
                   <td className="px-6 py-3.5">
                     <div className="flex items-center gap-3">
                       <Avatar name={item.stockName} src={item.stockLogo} size={34} />

--- a/src/components/account/PortfolioChart.tsx
+++ b/src/components/account/PortfolioChart.tsx
@@ -29,7 +29,7 @@ function toDisplayItems(items: PortfolioItem[]) {
   return [...top, { stockName: "기타", ratio: etcRatio }];
 }
 
-export default function PortfolioChart({ items }: { items: PortfolioItem[] }) {
+export default function PortfolioChart({ items, compact = false }: { items: PortfolioItem[]; compact?: boolean }) {
   const displayed = toDisplayItems(items);
   const [hovered, setHovered] = useState<PortfolioItem | null>(null);
 
@@ -64,10 +64,10 @@ export default function PortfolioChart({ items }: { items: PortfolioItem[] }) {
   const total = items.reduce((s, i) => s + i.ratio, 0);
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-100 p-6 h-full">
-      <h2 className="text-[16px] font-bold text-gray-900 mb-5">종목 비중</h2>
-      <div className="flex flex-col items-center gap-6">
-        <div className="relative w-56 h-56">
+    <div className={`bg-white rounded-2xl border border-gray-100 h-full ${compact ? "p-3" : "p-6"}`}>
+      <h2 className={`font-bold text-gray-900 ${compact ? "text-[13px] mb-3" : "text-[16px] mb-5"}`}>종목 비중</h2>
+      <div className="flex flex-col items-center gap-4">
+        <div className={`relative ${compact ? "w-36 h-36" : "w-56 h-56"}`}>
           <Doughnut data={chartData} options={options as never} />
           <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
             {hovered ? (

--- a/src/components/account/PortfolioChart.tsx
+++ b/src/components/account/PortfolioChart.tsx
@@ -22,6 +22,11 @@ const COLORS = [
 
 const TOP_N = 4;
 
+function fmt(n: number) {
+  if (Math.abs(n) >= 10000) return `${(n / 10000).toFixed(0)}만원`;
+  return `${n.toLocaleString()}원`;
+}
+
 function toDisplayItems(items: PortfolioItem[]) {
   if (items.length <= TOP_N + 1) return items;
   const top = items.slice(0, TOP_N);
@@ -29,7 +34,7 @@ function toDisplayItems(items: PortfolioItem[]) {
   return [...top, { stockName: "기타", ratio: etcRatio }];
 }
 
-export default function PortfolioChart({ items, compact = false }: { items: PortfolioItem[]; compact?: boolean }) {
+export default function PortfolioChart({ items, compact = false, totalEvaluation = 0 }: { items: PortfolioItem[]; compact?: boolean; totalEvaluation?: number }) {
   const displayed = toDisplayItems(items);
   const [hovered, setHovered] = useState<PortfolioItem | null>(null);
 
@@ -77,8 +82,8 @@ export default function PortfolioChart({ items, compact = false }: { items: Port
               </>
             ) : (
               <>
-                <p className={`${compact ? "text-[9px]" : "text-[11px]"} text-gray-400`}>총 자산</p>
-                <p className={`${compact ? "text-[11px]" : "text-[14px]"} font-bold text-gray-900`}>{total}%</p>
+                <p className={`${compact ? "text-[9px]" : "text-[11px]"} text-gray-400`}>총 평가금액</p>
+                <p className={`${compact ? "text-[11px]" : "text-[14px]"} font-bold text-gray-900`}>{fmt(totalEvaluation)}</p>
               </>
             )}
           </div>

--- a/src/components/account/PortfolioChart.tsx
+++ b/src/components/account/PortfolioChart.tsx
@@ -20,10 +20,10 @@ const COLORS = [
   "#84CC16",
 ];
 
-const TOP_N = 5;
+const TOP_N = 4;
 
 function toDisplayItems(items: PortfolioItem[]) {
-  if (items.length <= TOP_N) return items;
+  if (items.length <= TOP_N + 1) return items;
   const top = items.slice(0, TOP_N);
   const etcRatio = items.slice(TOP_N).reduce((s, i) => s + i.ratio, 0);
   return [...top, { stockName: "기타", ratio: etcRatio }];

--- a/src/components/account/PortfolioChart.tsx
+++ b/src/components/account/PortfolioChart.tsx
@@ -72,29 +72,29 @@ export default function PortfolioChart({ items, compact = false }: { items: Port
           <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
             {hovered ? (
               <>
-                <p className="text-[11px] text-gray-400">{hovered.stockName}</p>
-                <p className="text-[14px] font-bold text-gray-900">{hovered.ratio}%</p>
+                <p className={`${compact ? "text-[9px]" : "text-[11px]"} text-gray-400`}>{hovered.stockName}</p>
+                <p className={`${compact ? "text-[11px]" : "text-[14px]"} font-bold text-gray-900`}>{hovered.ratio}%</p>
               </>
             ) : (
               <>
-                <p className="text-[11px] text-gray-400">총 자산</p>
-                <p className="text-[14px] font-bold text-gray-900">{total}%</p>
+                <p className={`${compact ? "text-[9px]" : "text-[11px]"} text-gray-400`}>총 자산</p>
+                <p className={`${compact ? "text-[11px]" : "text-[14px]"} font-bold text-gray-900`}>{total}%</p>
               </>
             )}
           </div>
         </div>
 
-        <div className="w-full flex flex-col gap-2.5">
+        <div className="w-full flex flex-col gap-1.5">
           {displayed.map((item, idx) => (
             <div key={item.stockName} className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-1.5">
                 <span
-                  className="w-2.5 h-2.5 rounded-full shrink-0"
+                  className={`${compact ? "w-2 h-2" : "w-2.5 h-2.5"} rounded-full shrink-0`}
                   style={{ backgroundColor: COLORS[idx % COLORS.length] }}
                 />
-                <span className="text-[13px] text-gray-700">{item.stockName}</span>
+                <span className={`${compact ? "text-[11px]" : "text-[13px]"} text-gray-700`}>{item.stockName}</span>
               </div>
-              <span className="text-[13px] font-medium text-gray-500">{item.ratio}%</span>
+              <span className={`${compact ? "text-[11px]" : "text-[13px]"} font-medium text-gray-500`}>{item.ratio}%</span>
             </div>
           ))}
         </div>

--- a/src/components/profile/DeleteAccountModal.tsx
+++ b/src/components/profile/DeleteAccountModal.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import Button from "@/components/ui/Button";
+import { fetchClient } from "@/lib/fetchClient";
+import type { ApiResponse } from "@/api/authApi";
+
+type Props = {
+  onClose: () => void;
+  onDeleted: () => void;
+};
+
+export default function DeleteAccountModal({ onClose, onDeleted }: Props) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleDelete = async () => {
+    if (!password.trim()) return;
+    setLoading(true);
+    try {
+      await fetchClient.delete<ApiResponse<void>>("/api/users/me", { password });
+      onDeleted();
+    } catch {
+      setError("비밀번호가 올바르지 않습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
+      <div className="bg-white rounded-2xl w-80 shadow-xl p-6" onClick={(e) => e.stopPropagation()}>
+        <div className="flex flex-col items-center mb-5">
+          <div className="w-12 h-12 rounded-full bg-red-50 flex items-center justify-center mb-3">
+            <Trash2 size={22} className="text-red-500" />
+          </div>
+          <p className="text-[15px] font-bold text-gray-900 mb-1">회원탈퇴</p>
+          <p className="text-[13px] text-gray-400 text-center">정말 이 모든 데이터가 삭제됩니다.</p>
+        </div>
+
+        <div className="mb-1">
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => { setPassword(e.target.value); setError(""); }}
+            placeholder="비밀번호 확인"
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-[14px] outline-none focus:border-red-400"
+          />
+          {error && <p className="text-[11px] text-red-500 mt-1">{error}</p>}
+        </div>
+
+        <div className="flex gap-2 mt-4">
+          <Button variant="ghost" className="flex-1" onClick={onClose}>취소</Button>
+          <Button variant="danger" className="flex-1" onClick={handleDelete} disabled={!password || loading}>
+            {loading ? "처리 중..." : "탈퇴"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/DeleteAccountModal.tsx
+++ b/src/components/profile/DeleteAccountModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Trash2 } from "lucide-react";
+import { X } from "lucide-react";
 import Button from "@/components/ui/Button";
 import { fetchClient } from "@/lib/fetchClient";
 import type { ApiResponse } from "@/api/authApi";
@@ -19,44 +19,50 @@ export default function DeleteAccountModal({ onClose, onDeleted }: Props) {
     setLoading(true);
     setError("");
     try {
-      // 1단계: 비밀번호 확인
       await fetchClient.post<ApiResponse<void>>("/api/users/password/check", { password });
-      // 2단계: 회원 탈퇴
       await fetchClient.delete<ApiResponse<void>>("/api/users");
       onDeleted();
     } catch {
-      setError("비밀번호가 올바르지 않습니다.");
+      setError("비밀번호가 올바르지 않아요.");
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
-      <div className="bg-white rounded-2xl w-80 shadow-xl p-6" onClick={(e) => e.stopPropagation()}>
-        <div className="flex flex-col items-center mb-5">
-          <div className="w-12 h-12 rounded-full bg-red-50 flex items-center justify-center mb-3">
-            <Trash2 size={22} className="text-red-500" />
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div className="bg-white rounded-2xl w-[360px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <p className="text-[15px] font-bold text-gray-900">회원탈퇴</p>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors">
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-6 py-6 flex flex-col gap-4">
+          <div>
+            <p className="text-[14px] text-gray-700 font-medium mb-1">탈퇴 전 본인 확인이 필요해요</p>
+            <p className="text-[13px] text-gray-400">비밀번호를 입력하면 계정이 영구적으로 삭제돼요.</p>
           </div>
-          <p className="text-[15px] font-bold text-gray-900 mb-1">회원탈퇴</p>
-          <p className="text-[13px] text-gray-400 text-center">정말 이 모든 데이터가 삭제됩니다.</p>
+
+          <div>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => { setPassword(e.target.value); setError(""); }}
+              placeholder="비밀번호를 입력해주세요"
+              className="w-full border border-gray-200 rounded-xl px-3.5 py-2.5 text-[14px] outline-none focus:border-red-400 transition-colors"
+              onKeyDown={(e) => e.key === "Enter" && handleDelete()}
+            />
+            {error && <p className="text-[12px] text-red-500 mt-1.5">{error}</p>}
+          </div>
         </div>
 
-        <div>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => { setPassword(e.target.value); setError(""); }}
-            placeholder="비밀번호 확인"
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-[14px] outline-none focus:border-red-400"
-          />
-          {error && <p className="text-[11px] text-red-500 mt-1">{error}</p>}
-        </div>
-
-        <div className="flex gap-2 mt-4">
-          <Button variant="invalid" className="flex-1" onClick={onClose}>취소</Button>
-          <Button variant="danger" className="flex-1" onClick={handleDelete} disabled={!password || loading}>
-            {loading ? "처리 중..." : "탈퇴"}
+        <div className="flex gap-2 px-6 pb-6">
+          <Button variant="invalid" className="flex-1 py-2.5" onClick={onClose}>취소</Button>
+          <Button variant="danger" className="flex-1 py-2.5" onClick={handleDelete} disabled={!password || loading}>
+            {loading ? "처리 중..." : "탈퇴하기"}
           </Button>
         </div>
       </div>

--- a/src/components/profile/DeleteAccountModal.tsx
+++ b/src/components/profile/DeleteAccountModal.tsx
@@ -17,8 +17,12 @@ export default function DeleteAccountModal({ onClose, onDeleted }: Props) {
   const handleDelete = async () => {
     if (!password.trim()) return;
     setLoading(true);
+    setError("");
     try {
-      await fetchClient.delete<ApiResponse<void>>("/api/users/me", { password });
+      // 1단계: 비밀번호 확인
+      await fetchClient.post<ApiResponse<void>>("/api/users/password/check", { password });
+      // 2단계: 회원 탈퇴
+      await fetchClient.delete<ApiResponse<void>>("/api/users");
       onDeleted();
     } catch {
       setError("비밀번호가 올바르지 않습니다.");
@@ -38,7 +42,7 @@ export default function DeleteAccountModal({ onClose, onDeleted }: Props) {
           <p className="text-[13px] text-gray-400 text-center">정말 이 모든 데이터가 삭제됩니다.</p>
         </div>
 
-        <div className="mb-1">
+        <div>
           <input
             type="password"
             value={password}
@@ -50,7 +54,7 @@ export default function DeleteAccountModal({ onClose, onDeleted }: Props) {
         </div>
 
         <div className="flex gap-2 mt-4">
-          <Button variant="ghost" className="flex-1" onClick={onClose}>취소</Button>
+          <Button variant="invalid" className="flex-1" onClick={onClose}>취소</Button>
           <Button variant="danger" className="flex-1" onClick={handleDelete} disabled={!password || loading}>
             {loading ? "처리 중..." : "탈퇴"}
           </Button>

--- a/src/components/profile/EditProfileModal.tsx
+++ b/src/components/profile/EditProfileModal.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
-import { X } from "lucide-react";
+import { useState, useRef } from "react";
+import { X, Camera } from "lucide-react";
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
 import { fetchClient } from "@/lib/fetchClient";
+import { useAuthStore } from "@/store/authStore";
 import type { ApiResponse } from "@/api/authApi";
 
 type Props = {
@@ -13,86 +14,129 @@ type Props = {
 };
 
 export default function EditProfileModal({ nickname, profileImageUrl, onClose, onSave }: Props) {
-  const [value, setValue] = useState(nickname);
-  const [checked, setChecked] = useState(false);
-  const [checking, setChecking] = useState(false);
+  const [nicknameValue, setNicknameValue] = useState(nickname);
+  const [nicknameChecked, setNicknameChecked] = useState(false);
   const [nicknameMsg, setNicknameMsg] = useState<{ text: string; ok: boolean } | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
 
   const handleNicknameChange = (v: string) => {
-    setValue(v);
-    setChecked(false);
+    setNicknameValue(v);
+    setNicknameChecked(false);
     setNicknameMsg(null);
   };
 
   const handleCheckNickname = async () => {
-    if (!value.trim()) return;
-    if (value === nickname) {
-      setChecked(true);
+    if (!nicknameValue.trim() || nicknameValue === nickname) {
+      setNicknameChecked(true);
       return;
     }
     setChecking(true);
     try {
-      await fetchClient.get<ApiResponse<void>>("/api/auth/nickname/check", { nickname: value });
-      setChecked(true);
-      setNicknameMsg({ text: "사용 가능한 닉네임입니다.", ok: true });
+      await fetchClient.get<ApiResponse<void>>("/api/auth/nickname/check", { nickname: nicknameValue });
+      setNicknameChecked(true);
+      setNicknameMsg({ text: "사용 가능한 닉네임이에요.", ok: true });
     } catch {
-      setNicknameMsg({ text: "이미 사용 중인 닉네임입니다.", ok: false });
+      setNicknameMsg({ text: "이미 사용 중인 닉네임이에요.", ok: false });
     } finally {
       setChecking(false);
     }
   };
 
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImageFile(file);
+    setImagePreview(URL.createObjectURL(file));
+  };
+
   const handleSave = async () => {
     setSaving(true);
     try {
-      await fetchClient.patch<ApiResponse<void>>("/api/users/profile", { nickname: value });
-      onSave(value);
+      const token = useAuthStore.getState().accessToken;
+      const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+      const formData = new FormData();
+      formData.append("nickname", nicknameValue);
+      if (imageFile) formData.append("profileImage", imageFile);
+
+      await fetch(`${BASE_URL}/api/users/profile`, {
+        method: "PATCH",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        credentials: "include",
+        body: formData,
+      });
+
+      onSave(nicknameValue);
       onClose();
     } catch {
-      setNicknameMsg({ text: "저장에 실패했습니다.", ok: false });
+      setNicknameMsg({ text: "저장에 실패했어요. 다시 시도해주세요.", ok: false });
     } finally {
       setSaving(false);
     }
   };
 
-  const canSave = value.trim() && (value === nickname || checked) && nicknameMsg?.ok !== false;
+  const canSave =
+    nicknameValue.trim() &&
+    (nicknameValue === nickname || nicknameChecked) &&
+    nicknameMsg?.ok !== false;
+
+  const displayImage = imagePreview ?? profileImageUrl ?? undefined;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
-      <div className="bg-white rounded-2xl w-96 shadow-xl p-6" onClick={(e) => e.stopPropagation()}>
-        <div className="flex items-center justify-between mb-5">
-          <p className="text-[16px] font-bold text-gray-900">프로필 편집</p>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600"><X size={18} /></button>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div className="bg-white rounded-2xl w-[400px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <p className="text-[15px] font-bold text-gray-900">프로필 편집</p>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors">
+            <X size={18} />
+          </button>
         </div>
 
-        <div className="flex justify-center mb-5">
-          <Avatar name={value} src={profileImageUrl ?? undefined} size={72} />
-        </div>
-
-        <div>
-          <p className="text-[12px] text-gray-400 mb-1.5">닉네임</p>
-          <div className="flex gap-2">
-            <input
-              value={value}
-              onChange={(e) => handleNicknameChange(e.target.value)}
-              className="flex-1 border border-gray-200 rounded-lg px-3 py-2 text-[14px] outline-none focus:border-[#0046FF]"
-              placeholder="닉네임"
-            />
-            <Button variant="basic" onClick={handleCheckNickname} disabled={checking}>
-              {checking ? "확인 중" : "중복확인"}
-            </Button>
+        <div className="px-6 py-6 flex flex-col gap-5">
+          {/* 프로필 이미지 */}
+          <div className="flex justify-center">
+            <button
+              className="relative group"
+              onClick={() => fileRef.current?.click()}
+            >
+              <Avatar name={nicknameValue} src={displayImage} size={80} />
+              <div className="absolute inset-0 rounded-full bg-black/30 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                <Camera size={20} className="text-white" />
+              </div>
+            </button>
+            <input ref={fileRef} type="file" accept="image/*" className="hidden" onChange={handleImageChange} />
           </div>
-          {nicknameMsg && (
-            <p className={`text-[11px] mt-1 ${nicknameMsg.ok ? "text-blue-500" : "text-red-500"}`}>
-              {nicknameMsg.text}
-            </p>
-          )}
+
+          {/* 닉네임 */}
+          <div>
+            <p className="text-[12px] font-medium text-gray-500 mb-2">닉네임</p>
+            <div className="flex gap-2">
+              <input
+                value={nicknameValue}
+                onChange={(e) => handleNicknameChange(e.target.value)}
+                className="flex-1 border border-gray-200 rounded-xl px-3.5 py-2.5 text-[14px] outline-none focus:border-[#0046FF] transition-colors"
+                placeholder="닉네임을 입력해주세요"
+              />
+              <Button variant="basic" className="px-3 text-[13px] whitespace-nowrap" onClick={handleCheckNickname} disabled={checking}>
+                {checking ? "확인 중" : "중복확인"}
+              </Button>
+            </div>
+            {nicknameMsg && (
+              <p className={`text-[12px] mt-1.5 ${nicknameMsg.ok ? "text-[#0046FF]" : "text-red-500"}`}>
+                {nicknameMsg.text}
+              </p>
+            )}
+          </div>
         </div>
 
-        <div className="flex gap-2 mt-5">
-          <Button variant="invalid" className="flex-1" onClick={onClose}>취소</Button>
-          <Button variant="primary" className="flex-1" onClick={handleSave} disabled={!canSave || saving}>
+        {/* 버튼 */}
+        <div className="flex gap-2 px-6 pb-6">
+          <Button variant="invalid" className="flex-1 py-2.5" onClick={onClose}>취소</Button>
+          <Button variant="primary" className="flex-1 py-2.5" onClick={handleSave} disabled={!canSave || saving}>
             {saving ? "저장 중..." : "저장"}
           </Button>
         </div>

--- a/src/components/profile/EditProfileModal.tsx
+++ b/src/components/profile/EditProfileModal.tsx
@@ -16,17 +16,18 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
   const [value, setValue] = useState(nickname);
   const [checked, setChecked] = useState(false);
   const [checking, setChecking] = useState(false);
-  const [nicknameError, setNicknameError] = useState("");
+  const [nicknameMsg, setNicknameMsg] = useState<{ text: string; ok: boolean } | null>(null);
   const [saving, setSaving] = useState(false);
 
   const handleNicknameChange = (v: string) => {
     setValue(v);
     setChecked(false);
-    setNicknameError("");
+    setNicknameMsg(null);
   };
 
   const handleCheckNickname = async () => {
-    if (!value.trim() || value === nickname) {
+    if (!value.trim()) return;
+    if (value === nickname) {
       setChecked(true);
       return;
     }
@@ -34,29 +35,28 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
     try {
       await fetchClient.get<ApiResponse<void>>("/api/auth/nickname/check", { nickname: value });
       setChecked(true);
-      setNicknameError("");
+      setNicknameMsg({ text: "사용 가능한 닉네임입니다.", ok: true });
     } catch {
-      setNicknameError("이미 사용 중인 닉네임입니다.");
+      setNicknameMsg({ text: "이미 사용 중인 닉네임입니다.", ok: false });
     } finally {
       setChecking(false);
     }
   };
 
   const handleSave = async () => {
-    if (!checked && value !== nickname) return;
     setSaving(true);
     try {
-      await fetchClient.patch<ApiResponse<void>>("/api/users/me", { nickname: value });
+      await fetchClient.patch<ApiResponse<void>>("/api/users/profile", { nickname: value });
       onSave(value);
       onClose();
     } catch {
-      setNicknameError("저장에 실패했습니다.");
+      setNicknameMsg({ text: "저장에 실패했습니다.", ok: false });
     } finally {
       setSaving(false);
     }
   };
 
-  const canSave = value.trim() && (value === nickname || checked) && !nicknameError;
+  const canSave = value.trim() && (value === nickname || checked) && nicknameMsg?.ok !== false;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
@@ -66,15 +66,11 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600"><X size={18} /></button>
         </div>
 
-        {/* 아바타 */}
         <div className="flex justify-center mb-5">
-          <div className="relative">
-            <Avatar name={value} src={profileImageUrl ?? undefined} size={72} />
-          </div>
+          <Avatar name={value} src={profileImageUrl ?? undefined} size={72} />
         </div>
 
-        {/* 닉네임 */}
-        <div className="mb-1">
+        <div>
           <p className="text-[12px] text-gray-400 mb-1.5">닉네임</p>
           <div className="flex gap-2">
             <input
@@ -87,14 +83,15 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
               {checking ? "확인 중" : "중복확인"}
             </Button>
           </div>
-          {nicknameError && <p className="text-[11px] text-red-500 mt-1">{nicknameError}</p>}
-          {checked && !nicknameError && value !== nickname && (
-            <p className="text-[11px] text-blue-500 mt-1">사용 가능한 닉네임입니다.</p>
+          {nicknameMsg && (
+            <p className={`text-[11px] mt-1 ${nicknameMsg.ok ? "text-blue-500" : "text-red-500"}`}>
+              {nicknameMsg.text}
+            </p>
           )}
         </div>
 
         <div className="flex gap-2 mt-5">
-          <Button variant="ghost" className="flex-1" onClick={onClose}>취소</Button>
+          <Button variant="invalid" className="flex-1" onClick={onClose}>취소</Button>
           <Button variant="primary" className="flex-1" onClick={handleSave} disabled={!canSave || saving}>
             {saving ? "저장 중..." : "저장"}
           </Button>

--- a/src/components/profile/EditProfileModal.tsx
+++ b/src/components/profile/EditProfileModal.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import Avatar from "@/components/ui/Avatar";
+import Button from "@/components/ui/Button";
+import { fetchClient } from "@/lib/fetchClient";
+import type { ApiResponse } from "@/api/authApi";
+
+type Props = {
+  nickname: string;
+  profileImageUrl?: string | null;
+  onClose: () => void;
+  onSave: (newNickname: string) => void;
+};
+
+export default function EditProfileModal({ nickname, profileImageUrl, onClose, onSave }: Props) {
+  const [value, setValue] = useState(nickname);
+  const [checked, setChecked] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [nicknameError, setNicknameError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const handleNicknameChange = (v: string) => {
+    setValue(v);
+    setChecked(false);
+    setNicknameError("");
+  };
+
+  const handleCheckNickname = async () => {
+    if (!value.trim() || value === nickname) {
+      setChecked(true);
+      return;
+    }
+    setChecking(true);
+    try {
+      await fetchClient.get<ApiResponse<void>>("/api/auth/nickname/check", { nickname: value });
+      setChecked(true);
+      setNicknameError("");
+    } catch {
+      setNicknameError("이미 사용 중인 닉네임입니다.");
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!checked && value !== nickname) return;
+    setSaving(true);
+    try {
+      await fetchClient.patch<ApiResponse<void>>("/api/users/me", { nickname: value });
+      onSave(value);
+      onClose();
+    } catch {
+      setNicknameError("저장에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const canSave = value.trim() && (value === nickname || checked) && !nicknameError;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
+      <div className="bg-white rounded-2xl w-96 shadow-xl p-6" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-5">
+          <p className="text-[16px] font-bold text-gray-900">프로필 편집</p>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600"><X size={18} /></button>
+        </div>
+
+        {/* 아바타 */}
+        <div className="flex justify-center mb-5">
+          <div className="relative">
+            <Avatar name={value} src={profileImageUrl ?? undefined} size={72} />
+          </div>
+        </div>
+
+        {/* 닉네임 */}
+        <div className="mb-1">
+          <p className="text-[12px] text-gray-400 mb-1.5">닉네임</p>
+          <div className="flex gap-2">
+            <input
+              value={value}
+              onChange={(e) => handleNicknameChange(e.target.value)}
+              className="flex-1 border border-gray-200 rounded-lg px-3 py-2 text-[14px] outline-none focus:border-[#0046FF]"
+              placeholder="닉네임"
+            />
+            <Button variant="basic" onClick={handleCheckNickname} disabled={checking}>
+              {checking ? "확인 중" : "중복확인"}
+            </Button>
+          </div>
+          {nicknameError && <p className="text-[11px] text-red-500 mt-1">{nicknameError}</p>}
+          {checked && !nicknameError && value !== nickname && (
+            <p className="text-[11px] text-blue-500 mt-1">사용 가능한 닉네임입니다.</p>
+          )}
+        </div>
+
+        <div className="flex gap-2 mt-5">
+          <Button variant="ghost" className="flex-1" onClick={onClose}>취소</Button>
+          <Button variant="primary" className="flex-1" onClick={handleSave} disabled={!canSave || saving}>
+            {saving ? "저장 중..." : "저장"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/FollowList.tsx
+++ b/src/components/profile/FollowList.tsx
@@ -1,0 +1,34 @@
+import Avatar from "@/components/ui/Avatar";
+import type { FollowUser } from "@/api/userListApi";
+
+type Props = {
+  type: "followers" | "following";
+  items: FollowUser[];
+};
+
+const LABEL = { followers: "팔로워", following: "팔로잉" };
+
+export default function FollowList({ type, items }: Props) {
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 mt-3 flex-1 overflow-y-auto">
+      <p className="text-[13px] font-semibold text-gray-700 px-4 pt-4 pb-2">{LABEL[type]}</p>
+      {items.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center py-10">
+          <p className="text-[12px] text-gray-400">{LABEL[type]}이 없습니다.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col pb-2">
+          {items.map((user) => (
+            <div
+              key={user.userId}
+              className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors"
+            >
+              <Avatar name={user.nickname} src={user.imageUrl} size={32} />
+              <span className="text-[13px] font-medium text-gray-800">{user.nickname}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/LogoutModal.tsx
+++ b/src/components/profile/LogoutModal.tsx
@@ -1,0 +1,23 @@
+import Button from "@/components/ui/Button";
+
+type Props = {
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+export default function LogoutModal({ onClose, onConfirm }: Props) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
+      <div className="bg-white rounded-2xl w-80 shadow-xl p-6" onClick={(e) => e.stopPropagation()}>
+        <div className="text-center mb-5">
+          <p className="text-[15px] font-bold text-gray-900 mb-2">로그아웃</p>
+          <p className="text-[13px] text-gray-400">정말 로그아웃 하시겠습니까?</p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="ghost" className="flex-1" onClick={onClose}>취소</Button>
+          <Button variant="primary" className="flex-1" onClick={onConfirm}>로그아웃</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/LogoutModal.tsx
+++ b/src/components/profile/LogoutModal.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-react";
 import Button from "@/components/ui/Button";
 
 type Props = {
@@ -7,15 +8,24 @@ type Props = {
 
 export default function LogoutModal({ onClose, onConfirm }: Props) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={onClose}>
-      <div className="bg-white rounded-2xl w-80 shadow-xl p-6" onClick={(e) => e.stopPropagation()}>
-        <div className="text-center mb-5">
-          <p className="text-[15px] font-bold text-gray-900 mb-2">로그아웃</p>
-          <p className="text-[13px] text-gray-400">정말 로그아웃 하시겠습니까?</p>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div className="bg-white rounded-2xl w-[360px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <p className="text-[15px] font-bold text-gray-900">로그아웃</p>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors">
+            <X size={18} />
+          </button>
         </div>
-        <div className="flex gap-2">
-          <Button variant="ghost" className="flex-1" onClick={onClose}>취소</Button>
-          <Button variant="primary" className="flex-1" onClick={onConfirm}>로그아웃</Button>
+
+        <div className="px-6 py-6">
+          <p className="text-[14px] text-gray-700 font-medium mb-1">로그아웃 하시겠어요?</p>
+          <p className="text-[13px] text-gray-400">언제든지 다시 로그인할 수 있어요.</p>
+        </div>
+
+        <div className="flex gap-2 px-6 pb-6">
+          <Button variant="invalid" className="flex-1 py-2.5" onClick={onClose}>취소</Button>
+          <Button variant="primary" className="flex-1 py-2.5" onClick={onConfirm}>로그아웃</Button>
         </div>
       </div>
     </div>

--- a/src/components/profile/PortfolioTab.tsx
+++ b/src/components/profile/PortfolioTab.tsx
@@ -48,7 +48,7 @@ export default function PortfolioTab({
       </div>
 
       <div className="grid grid-cols-[1fr_2fr] gap-3 flex-1 min-h-0">
-        <PortfolioChart items={portfolio} compact />
+        <PortfolioChart items={portfolio} compact totalEvaluation={totalEvaluation} />
         <HoldingList items={holdings} showAvgPrice={false} compact />
       </div>
     </div>

--- a/src/components/profile/PortfolioTab.tsx
+++ b/src/components/profile/PortfolioTab.tsx
@@ -1,0 +1,51 @@
+import SummaryCard from "@/components/account/SummaryCard";
+import PortfolioChart from "@/components/account/PortfolioChart";
+import HoldingList from "@/components/account/HoldingList";
+import type { PortfolioItem } from "@/components/account/PortfolioChart";
+import type { HoldingItem } from "@/components/account/HoldingList";
+
+type Props = {
+  totalEvaluation: number;
+  totalReturnRate: number;
+  totalReturnAmount: number;
+  portfolio: PortfolioItem[];
+  holdings: HoldingItem[];
+};
+
+function fmt(n: number) {
+  if (Math.abs(n) >= 10000) return `${(n / 10000).toFixed(0)}만원`;
+  return `${n.toLocaleString()}원`;
+}
+
+export default function PortfolioTab({
+  totalEvaluation,
+  totalReturnRate,
+  totalReturnAmount,
+  portfolio,
+  holdings,
+}: Props) {
+  const isPositive = totalReturnRate >= 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-3 gap-4">
+        <SummaryCard label="총 평가금액" value={fmt(totalEvaluation)} />
+        <SummaryCard
+          label="총 수익률"
+          value={`${isPositive ? "+" : ""}${totalReturnRate.toFixed(2)}%`}
+          valueColor={isPositive ? "text-red-500" : "text-blue-500"}
+        />
+        <SummaryCard
+          label="총 수익"
+          value={`${isPositive ? "+" : ""}${fmt(totalReturnAmount)}`}
+          valueColor={isPositive ? "text-red-500" : "text-blue-500"}
+        />
+      </div>
+
+      <div className="grid grid-cols-[1fr_2fr] gap-4 h-130">
+        <PortfolioChart items={portfolio} />
+        <HoldingList items={holdings} showAvgPrice={false} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/PortfolioTab.tsx
+++ b/src/components/profile/PortfolioTab.tsx
@@ -27,7 +27,7 @@ export default function PortfolioTab({
   const isPositive = totalReturnRate >= 0;
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 h-full">
       <div className="grid grid-cols-3 gap-3">
         <div className="rounded-xl px-4 py-3 bg-white border border-gray-100">
           <p className="text-[11px] font-medium text-gray-400 mb-1">총 평가금액</p>
@@ -47,7 +47,7 @@ export default function PortfolioTab({
         </div>
       </div>
 
-      <div className="grid grid-cols-[1fr_2fr] gap-3 h-[460px]">
+      <div className="grid grid-cols-[1fr_2fr] gap-3 flex-1 min-h-0">
         <PortfolioChart items={portfolio} compact />
         <HoldingList items={holdings} showAvgPrice={false} compact />
       </div>

--- a/src/components/profile/PortfolioTab.tsx
+++ b/src/components/profile/PortfolioTab.tsx
@@ -27,24 +27,29 @@ export default function PortfolioTab({
   const isPositive = totalReturnRate >= 0;
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="grid grid-cols-3 gap-4">
-        <SummaryCard label="총 평가금액" value={fmt(totalEvaluation)} />
-        <SummaryCard
-          label="총 수익률"
-          value={`${isPositive ? "+" : ""}${totalReturnRate.toFixed(2)}%`}
-          valueColor={isPositive ? "text-red-500" : "text-blue-500"}
-        />
-        <SummaryCard
-          label="총 수익"
-          value={`${isPositive ? "+" : ""}${fmt(totalReturnAmount)}`}
-          valueColor={isPositive ? "text-red-500" : "text-blue-500"}
-        />
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-3 gap-3">
+        <div className="rounded-xl px-4 py-3 bg-white border border-gray-100">
+          <p className="text-[11px] font-medium text-gray-400 mb-1">총 평가금액</p>
+          <p className="text-[16px] font-bold text-gray-900">{fmt(totalEvaluation)}</p>
+        </div>
+        <div className="rounded-xl px-4 py-3 bg-white border border-gray-100">
+          <p className="text-[11px] font-medium text-gray-400 mb-1">총 수익률</p>
+          <p className={`text-[16px] font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+            {isPositive ? "+" : ""}{totalReturnRate.toFixed(2)}%
+          </p>
+        </div>
+        <div className="rounded-xl px-4 py-3 bg-white border border-gray-100">
+          <p className="text-[11px] font-medium text-gray-400 mb-1">총 수익</p>
+          <p className={`text-[16px] font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+            {isPositive ? "+" : ""}{fmt(totalReturnAmount)}
+          </p>
+        </div>
       </div>
 
-      <div className="grid grid-cols-[1fr_2fr] gap-4 h-130">
-        <PortfolioChart items={portfolio} />
-        <HoldingList items={holdings} showAvgPrice={false} />
+      <div className="grid grid-cols-[1fr_2fr] gap-3 h-[460px]">
+        <PortfolioChart items={portfolio} compact />
+        <HoldingList items={holdings} showAvgPrice={false} compact />
       </div>
     </div>
   );

--- a/src/components/profile/PortfolioTab.tsx
+++ b/src/components/profile/PortfolioTab.tsx
@@ -1,108 +1,50 @@
-import Avatar from "@/components/ui/Avatar";
-
-export type PortfolioHolding = {
-  stockId: string;
-  stockName: string;
-  quantity: number;
-  profitLossRate: number;
-};
-
-export type PortfolioData = {
-  totalValue: number;
-  totalProfitLoss: number;
-  totalProfitLossRate: number;
-  holdings: PortfolioHolding[];
-};
+import SummaryCard from "@/components/account/SummaryCard";
+import PortfolioChart from "@/components/account/PortfolioChart";
+import HoldingList from "@/components/account/HoldingList";
+import type { PortfolioItem } from "@/components/account/PortfolioChart";
+import type { HoldingItem } from "@/components/account/HoldingList";
 
 type Props = {
-  data: PortfolioData;
+  totalEvaluation: number;
+  totalReturnRate: number;
+  totalReturnAmount: number;
+  portfolio: PortfolioItem[];
+  holdings: HoldingItem[];
 };
 
-function fmtAmount(n: number) {
-  if (Math.abs(n) >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}억`;
-  if (Math.abs(n) >= 10_000) return `${(n / 10_000).toFixed(0)}만`;
-  return n.toLocaleString("ko-KR");
+function fmt(n: number) {
+  if (Math.abs(n) >= 10000) return `${(n / 10000).toFixed(0)}만원`;
+  return `${n.toLocaleString()}원`;
 }
 
-export default function PortfolioTab({ data }: Props) {
-  const isPositive = data.totalProfitLossRate >= 0;
+export default function PortfolioTab({
+  totalEvaluation,
+  totalReturnRate,
+  totalReturnAmount,
+  portfolio,
+  holdings,
+}: Props) {
+  const isPositive = totalReturnRate >= 0;
 
   return (
-    <div className="flex flex-col gap-5">
-      {/* 요약 */}
-      <div className="grid grid-cols-3 gap-3">
-        <div className="p-4 bg-gray-50 rounded-xl">
-          <p className="text-[12px] text-gray-400 mb-1">총 평가금액</p>
-          <p className="text-[16px] font-bold text-gray-900">
-            {fmtAmount(data.totalValue)}원
-          </p>
-        </div>
-        <div className="p-4 bg-gray-50 rounded-xl">
-          <p className="text-[12px] text-gray-400 mb-1">총 수익률</p>
-          <p
-            className={`text-[16px] font-bold ${
-              isPositive ? "text-[#FF4444]" : "text-[#0046FF]"
-            }`}
-          >
-            {isPositive ? "+" : ""}
-            {data.totalProfitLossRate.toFixed(1)}%
-          </p>
-        </div>
-        <div className="p-4 bg-gray-50 rounded-xl">
-          <p className="text-[12px] text-gray-400 mb-1">총 수익</p>
-          <p
-            className={`text-[16px] font-bold ${
-              isPositive ? "text-[#FF4444]" : "text-[#0046FF]"
-            }`}
-          >
-            {isPositive ? "+" : ""}
-            {fmtAmount(data.totalProfitLoss)}원
-          </p>
-        </div>
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-3 gap-4">
+        <SummaryCard label="총 평가금액" value={fmt(totalEvaluation)} />
+        <SummaryCard
+          label="총 수익률"
+          value={`${isPositive ? "+" : ""}${totalReturnRate.toFixed(2)}%`}
+          valueColor={isPositive ? "text-red-500" : "text-blue-500"}
+        />
+        <SummaryCard
+          label="총 수익"
+          value={`${isPositive ? "+" : ""}${fmt(totalReturnAmount)}`}
+          valueColor={isPositive ? "text-red-500" : "text-blue-500"}
+        />
       </div>
 
-      {/* 보유 종목 */}
-      <div>
-        <p className="text-[14px] font-semibold text-gray-700 mb-3">보유 종목</p>
-        <div className="overflow-hidden rounded-xl border border-gray-100">
-          <table className="w-full">
-            <thead className="bg-gray-50">
-              <tr className="text-[12px] text-gray-400">
-                <th className="text-left px-4 py-3 font-semibold">종목</th>
-                <th className="text-right px-3 py-3 font-semibold">수량</th>
-                <th className="text-right px-4 py-3 font-semibold">수익률</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-50">
-              {data.holdings.map((h) => {
-                const isHoldingPositive = h.profitLossRate >= 0;
-                return (
-                  <tr key={h.stockId} className="hover:bg-gray-50 transition-colors">
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <Avatar name={h.stockName} size={28} />
-                        <span className="text-[13px] font-medium text-gray-800">
-                          {h.stockName}
-                        </span>
-                      </div>
-                    </td>
-                    <td className="px-3 py-3 text-right text-[12px] text-gray-500">
-                      {h.quantity}주
-                    </td>
-                    <td
-                      className={`px-4 py-3 text-right text-[13px] font-bold ${
-                        isHoldingPositive ? "text-[#FF4444]" : "text-[#0046FF]"
-                      }`}
-                    >
-                      {isHoldingPositive ? "+" : ""}
-                      {h.profitLossRate.toFixed(1)}%
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+      <div className="grid grid-cols-[1fr_2fr] gap-4 h-130">
+        <PortfolioChart items={portfolio} />
+        <HoldingList items={holdings} showAvgPrice={false} />
       </div>
     </div>
   );

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -108,7 +108,7 @@ export default function ProfileCard({
           <LogOut size={14} />
           로그아웃
         </Button>
-        <Button variant="invalid" className="w-full flex items-center justify-center gap-2 text-red-500 hover:bg-red-50!" onClick={onDeleteClick}>
+        <Button variant="danger" className="w-full flex items-center justify-center gap-2" onClick={onDeleteClick}>
           <Trash2 size={14} />
           회원탈퇴
         </Button>

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -1,0 +1,82 @@
+import Avatar from "@/components/ui/Avatar";
+import Button from "@/components/ui/Button";
+import { Pencil, LogOut, Trash2 } from "lucide-react";
+
+type Props = {
+  nickname: string;
+  email: string;
+  followerCount: number;
+  followingCount: number;
+  returnRate: number;
+  returnAmount: number;
+  onEditProfile?: () => void;
+  onLogout?: () => void;
+  onWithdraw?: () => void;
+};
+
+function fmt(n: number) {
+  if (Math.abs(n) >= 10000) return `${(n / 10000).toFixed(0)}만원`;
+  return `${n.toLocaleString()}원`;
+}
+
+export default function ProfileCard({
+  nickname,
+  email,
+  followerCount,
+  followingCount,
+  returnRate,
+  returnAmount,
+  onEditProfile,
+  onLogout,
+  onWithdraw,
+}: Props) {
+  const isPositive = returnRate >= 0;
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 p-6 flex flex-col items-center gap-5">
+      <div className="flex flex-col items-center gap-2">
+        <Avatar name={nickname} size={80} />
+        <div className="text-center">
+          <p className="text-[17px] font-bold text-gray-900">{nickname}</p>
+          <p className="text-[13px] text-gray-400 mt-0.5">{email}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 w-full border-y border-gray-100 py-3">
+        <div className="flex flex-col items-center gap-0.5 border-r border-gray-100">
+          <p className="text-[16px] font-bold text-gray-900">{followerCount}</p>
+          <p className="text-[12px] text-gray-400">팔로워</p>
+        </div>
+        <div className="flex flex-col items-center gap-0.5">
+          <p className="text-[16px] font-bold text-gray-900">{followingCount}</p>
+          <p className="text-[12px] text-gray-400">팔로잉</p>
+        </div>
+        <div className="flex flex-col items-center gap-0.5 border-r border-gray-100 pt-3">
+          <p className={`text-[16px] font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+            {isPositive ? "+" : ""}{returnRate.toFixed(2)}%
+          </p>
+          <p className="text-[12px] text-gray-400">수익률</p>
+        </div>
+        <div className="flex flex-col items-center gap-0.5 pt-3">
+          <p className={`text-[16px] font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+            {isPositive ? "+" : ""}{fmt(returnAmount)}
+          </p>
+          <p className="text-[12px] text-gray-400">총 수익</p>
+        </div>
+
+      </div>
+
+      <div className="flex flex-col w-full gap-2">
+        <Button variant="invalid" className="w-full flex items-center justify-center gap-1.5" onClick={onEditProfile}>
+          <Pencil size={14} />프로필 편집
+        </Button>
+        <Button variant="invalid" className="w-full flex items-center justify-center gap-1.5" onClick={onLogout}>
+          <LogOut size={14} />로그아웃
+        </Button>
+        <Button variant="danger" className="w-full flex items-center justify-center gap-1.5" onClick={onWithdraw}>
+          <Trash2 size={14} />회원탈퇴
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileTabs.tsx
+++ b/src/components/profile/ProfileTabs.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import TabBar from "@/components/ui/TabBar";
+import PortfolioTab from "@/components/profile/PortfolioTab";
+
+const TABS = [
+  { id: "diary", label: "매매일지" },
+  { id: "history", label: "매매내역" },
+  { id: "portfolio", label: "포트폴리오" },
+];
+
+const DUMMY_PORTFOLIO = [
+  { stockName: "KB금융", ratio: 17 },
+  { stockName: "삼성SDI", ratio: 14 },
+  { stockName: "NAVER", ratio: 13 },
+  { stockName: "현대차", ratio: 11 },
+  { stockName: "삼성물산", ratio: 8 },
+  { stockName: "기타", ratio: 37 },
+];
+
+const DUMMY_HOLDINGS = [
+  { tickerCode: "005930", stockName: "삼성전자", stockLogo: "", quantity: 15, averageBuyPrice: 68200, currentPrice: 73400, evaluationAmount: 1100000, profitRate: 7.62, profitAmount: 78000 },
+  { tickerCode: "000660", stockName: "SK하이닉스", stockLogo: "", quantity: 5, averageBuyPrice: 174000, currentPrice: 192500, evaluationAmount: 962500, profitRate: 10.63, profitAmount: 92500 },
+  { tickerCode: "035420", stockName: "NAVER", stockLogo: "", quantity: 12, averageBuyPrice: 178000, currentPrice: 192000, evaluationAmount: 2304000, profitRate: 7.87, profitAmount: 168000 },
+  { tickerCode: "005380", stockName: "현대차", stockLogo: "", quantity: 8, averageBuyPrice: 225000, currentPrice: 241500, evaluationAmount: 1932000, profitRate: 7.33, profitAmount: 132000 },
+  { tickerCode: "105560", stockName: "KB금융", stockLogo: "", quantity: 35, averageBuyPrice: 81500, currentPrice: 87200, evaluationAmount: 3052000, profitRate: 9.04, profitAmount: 253000 },
+  { tickerCode: "068270", stockName: "셀트리온", stockLogo: "", quantity: 4, averageBuyPrice: 162000, currentPrice: 178500, evaluationAmount: 714000, profitRate: 10.19, profitAmount: 66000 },
+];
+
+export default function ProfileTabs() {
+  const [activeTab, setActiveTab] = useState("portfolio");
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
+      <TabBar tabs={TABS} activeId={activeTab} onChange={setActiveTab} variant="underline" />
+
+      <div className="p-6">
+        {activeTab === "diary" && (
+          <div className="text-[14px] text-gray-400">매매일지 준비 중</div>
+        )}
+        {activeTab === "history" && (
+          <div className="text-[14px] text-gray-400">매매내역 준비 중</div>
+        )}
+        {activeTab === "portfolio" && (
+          <PortfolioTab
+            totalEvaluation={11250000}
+            totalReturnRate={12.5}
+            totalReturnAmount={1250000}
+            portfolio={DUMMY_PORTFOLIO}
+            holdings={DUMMY_HOLDINGS}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/TradeHistoryTab.tsx
+++ b/src/components/profile/TradeHistoryTab.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import Avatar from "@/components/ui/Avatar";
 import type { TradeHistoryItem } from "@/api/tradeApi";
 
@@ -6,6 +7,7 @@ type Props = {
 };
 
 export default function TradeHistoryTab({ items }: Props) {
+  const navigate = useNavigate();
   if (items.length === 0) {
     return (
       <div className="text-center py-12 text-[14px] text-gray-400">
@@ -34,7 +36,7 @@ export default function TradeHistoryTab({ items }: Props) {
             const isPositive = (item.profitAmount ?? 0) >= 0;
 
             return (
-              <tr key={index} className="hover:bg-gray-50 transition-colors">
+              <tr key={index} className={`hover:bg-gray-50 transition-colors ${item.tickerCode ? "cursor-pointer" : ""}`} onClick={() => item.tickerCode && navigate(`/invest/${item.tickerCode}`)}>
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">
                     <Avatar name={item.stockName} src={item.stockLogo} size={28} />

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/cn";
+
 type ButtonProps = {
   children: React.ReactNode;
   variant?: "primary" | "basic" | "invalid" | "danger";
@@ -25,12 +27,7 @@ export default function Button({
   return (
     <button
       style={{ width: width ? `${width}px` : undefined }}
-      className={[
-        "rounded-[10px]",
-        "py-1.5",
-        variantClass[variant],
-        className,
-      ].join(" ")}
+      className={cn("rounded-[10px] py-1.5", variantClass[variant], className)}
       disabled={disabled}
       onClick={onClick}
     >

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,6 +1,6 @@
 type ButtonProps = {
   children: React.ReactNode;
-  variant?: "primary" | "basic" | "invalid";
+  variant?: "primary" | "basic" | "invalid" | "danger";
   width?: number;
   className?: string;
   disabled?: boolean;
@@ -11,6 +11,7 @@ const variantClass = {
   primary: "bg-[#0046FF] text-white hover:bg-[#0038CC]",
   basic: "border border-[#0046FF] text-[#0046FF] hover:bg-blue-50",
   invalid: "text-gray-600 hover:bg-gray-100",
+  danger: "border border-red-200 bg-red-50 text-red-500 hover:bg-red-100",
 };
 
 export default function Button({

--- a/src/components/ui/TabBar.tsx
+++ b/src/components/ui/TabBar.tsx
@@ -6,9 +6,33 @@ type TabBarProps = {
   tabs: Tab[];
   activeId: string;
   onChange: (id: string) => void;
+  variant?: "pill" | "underline";
 };
 
-export default function TabBar({ tabs, activeId, onChange }: TabBarProps) {
+export default function TabBar({ tabs, activeId, onChange, variant = "pill" }: TabBarProps) {
+  if (variant === "underline") {
+    return (
+      <div className="flex border-b border-gray-100">
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeId;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => onChange(tab.id)}
+              className={`flex-1 py-3 text-[15px] font-semibold transition-colors duration-150 border-b-2 -mb-px ${
+                isActive
+                  ? "text-[#0046FF] border-[#0046FF]"
+                  : "text-gray-400 border-transparent hover:text-gray-600"
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <div className="flex gap-1">
       {tabs.map((tab) => {

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/pages/account/AccountPage.tsx
+++ b/src/pages/account/AccountPage.tsx
@@ -1,37 +1,31 @@
 import PortfolioChart from "@/components/account/PortfolioChart";
 import HoldingList from "@/components/account/HoldingList";
-import type { PortfolioItem } from "@/components/account/PortfolioChart";
-import type { HoldingItem } from "@/components/account/HoldingList";
-
-const DUMMY_PORTFOLIO: PortfolioItem[] = [
-  { stockName: "KB금융", ratio: 35 },
-  { stockName: "NAVER", ratio: 20 },
-  { stockName: "현대차", ratio: 17 },
-  { stockName: "SK하이닉스", ratio: 9 },
-  { stockName: "삼성전자", ratio: 10 },
-  { stockName: "셀트리온", ratio: 6 },
-];
-
-const DUMMY_HOLDINGS: HoldingItem[] = [
-  { tickerCode: "005930", stockName: "삼성전자", stockLogo: "", quantity: 15, averageBuyPrice: 68200, currentPrice: 73400, evaluationAmount: 1100000, profitRate: 7.62, profitAmount: 78000 },
-  { tickerCode: "000660", stockName: "SK하이닉스", stockLogo: "", quantity: 5, averageBuyPrice: 174000, currentPrice: 192500, evaluationAmount: 962500, profitRate: 10.63, profitAmount: 92500 },
-  { tickerCode: "035420", stockName: "NAVER", stockLogo: "", quantity: 12, averageBuyPrice: 178000, currentPrice: 192000, evaluationAmount: 2304000, profitRate: 7.87, profitAmount: 168000 },
-  { tickerCode: "005380", stockName: "현대차", stockLogo: "", quantity: 8, averageBuyPrice: 225000, currentPrice: 241500, evaluationAmount: 1932000, profitRate: 7.33, profitAmount: 132000 },
-  { tickerCode: "105560", stockName: "KB금융", stockLogo: "", quantity: 35, averageBuyPrice: 81500, currentPrice: 87200, evaluationAmount: 3052000, profitRate: 9.04, profitAmount: 253000 },
-  { tickerCode: "068270", stockName: "셀트리온", stockLogo: "", quantity: 4, averageBuyPrice: 162000, currentPrice: 178500, evaluationAmount: 714000, profitRate: 10.19, profitAmount: 66000 },
-];
+import { useAccountSummaryQuery, useHoldingsQuery } from "@/api/accountApi";
 
 function fmt(n: number) {
-  if (Math.abs(n) >= 10000) return `${(n / 10000).toFixed(0)}만원`;
+  if (Math.abs(n) >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}억원`;
+  if (Math.abs(n) >= 10_000) return `${(n / 10_000).toFixed(0)}만원`;
   return `${n.toLocaleString()}원`;
 }
 
-const totalAsset = 11250000;
-const totalProfit = 1250000;
-const totalProfitRate = 12.5;
-const isPositive = totalProfit >= 0;
-
 export default function AccountPage() {
+  const { data: summary } = useAccountSummaryQuery();
+  const { data: holdingsRaw = [] } = useHoldingsQuery();
+
+  const holdings = holdingsRaw.map((h) => ({
+    tickerCode: h.tickerCode,
+    stockName: h.stockName,
+    stockLogo: h.stockLogo,
+    quantity: h.quantity,
+    averageBuyPrice: h.avgPrice,
+    currentPrice: h.currentPrice,
+    evaluationAmount: h.evaluation,
+    profitRate: h.returnRate,
+    profitAmount: h.returnAmount,
+  }));
+
+  const isPositive = (summary?.totalReturnRate ?? 0) >= 0;
+
   return (
     <div className="flex flex-col h-full p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
       <div>
@@ -39,51 +33,53 @@ export default function AccountPage() {
         <p className="text-[13px] text-gray-400 mt-0.5">나의 투자 현황을 한눈에 확인하세요</p>
       </div>
 
-      {/* grid: [2fr 1fr 1fr 1fr] — 상단 요약 + 하단 차트/테이블 정렬 */}
       <div className="grid grid-cols-[2fr_1fr_1fr_1fr] gap-4 items-stretch">
 
         {/* 보유 총 자산 */}
         <div className="bg-[#0046FF] rounded-2xl px-6 py-5 text-white">
           <p className="text-[13px] font-medium opacity-80 mb-2">보유 총 자산</p>
-          <p className="text-[28px] font-bold">{fmt(totalAsset)}</p>
+          <p className="text-[28px] font-bold">{fmt(summary?.totalAsset ?? 0)}</p>
           <p className={`text-[13px] font-medium mt-1 ${isPositive ? "text-red-300" : "text-blue-200"}`}>
-            {isPositive ? "+" : ""}{fmt(totalProfit)} ({isPositive ? "+" : ""}{totalProfitRate.toFixed(2)}%)
+            {isPositive ? "+" : ""}{fmt(summary?.totalReturnAmount ?? 0)} ({isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(2)}%)
           </p>
         </div>
 
         {/* 보유 현금 */}
         <div className="bg-white rounded-2xl border border-gray-100 px-6 py-5">
           <p className="text-[13px] text-gray-400 font-medium mb-2">보유 현금</p>
-          <p className="text-[22px] font-bold text-gray-900">{fmt(2140000)}</p>
-          <p className="text-[12px] text-gray-400 mt-1">투자원금 {fmt(10000000)}</p>
+          <p className="text-[22px] font-bold text-gray-900">{fmt(summary?.cash ?? 0)}</p>
+          <p className="text-[12px] text-gray-400 mt-1">투자원금 {fmt(summary?.initialCash ?? 0)}</p>
         </div>
 
         {/* 보유 종목 */}
         <div className="bg-white rounded-2xl border border-gray-100 px-6 py-5">
           <p className="text-[13px] text-gray-400 font-medium mb-2">보유 종목</p>
-          <p className="text-[22px] font-bold text-gray-900">6개</p>
-          <p className="text-[12px] text-gray-400 mt-1">총 평가금약 {fmt(9110000)}</p>
+          <p className="text-[22px] font-bold text-gray-900">{summary?.holdingsCount ?? 0}개</p>
+          <p className="text-[12px] text-gray-400 mt-1">총 평가금액 {fmt(summary?.totalEvaluation ?? 0)}</p>
         </div>
 
         {/* 수익률 */}
         <div className="bg-white rounded-2xl border border-gray-100 px-6 py-5">
           <p className="text-[13px] text-gray-400 font-medium mb-2">수익률</p>
           <p className={`text-[22px] font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-            {isPositive ? "+" : ""}{totalProfitRate.toFixed(2)}%
+            {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(2)}%
           </p>
           <p className={`text-[12px] mt-1 font-medium ${isPositive ? "text-red-400" : "text-blue-400"}`}>
-            {isPositive ? "+" : ""}{fmt(totalProfit)}
+            {isPositive ? "+" : ""}{fmt(summary?.totalReturnAmount ?? 0)}
           </p>
         </div>
 
-        {/* 종목 비중 차트 — col 1 (2fr) */}
+        {/* 종목 비중 차트 */}
         <div className="row-start-2">
-          <PortfolioChart items={DUMMY_PORTFOLIO} />
+          <PortfolioChart
+            items={summary?.holdingsRatio ?? []}
+            totalEvaluation={summary?.totalEvaluation ?? 0}
+          />
         </div>
 
-        {/* 보유 종목 테이블 — col 2~4 (3fr) */}
+        {/* 보유 종목 테이블 */}
         <div className="col-span-3 row-start-2">
-          <HoldingList items={DUMMY_HOLDINGS} />
+          <HoldingList items={holdings} />
         </div>
       </div>
     </div>

--- a/src/pages/account/AccountPage.tsx
+++ b/src/pages/account/AccountPage.tsx
@@ -1,43 +1,37 @@
-import SummaryCard from "@/components/account/SummaryCard";
 import PortfolioChart from "@/components/account/PortfolioChart";
 import HoldingList from "@/components/account/HoldingList";
-import { useAccountSummaryQuery, useHoldingsQuery } from "@/api/accountApi";
+import type { PortfolioItem } from "@/components/account/PortfolioChart";
+import type { HoldingItem } from "@/components/account/HoldingList";
+
+const DUMMY_PORTFOLIO: PortfolioItem[] = [
+  { stockName: "KB금융", ratio: 35 },
+  { stockName: "NAVER", ratio: 20 },
+  { stockName: "현대차", ratio: 17 },
+  { stockName: "SK하이닉스", ratio: 9 },
+  { stockName: "삼성전자", ratio: 10 },
+  { stockName: "셀트리온", ratio: 6 },
+];
+
+const DUMMY_HOLDINGS: HoldingItem[] = [
+  { tickerCode: "005930", stockName: "삼성전자", stockLogo: "", quantity: 15, averageBuyPrice: 68200, currentPrice: 73400, evaluationAmount: 1100000, profitRate: 7.62, profitAmount: 78000 },
+  { tickerCode: "000660", stockName: "SK하이닉스", stockLogo: "", quantity: 5, averageBuyPrice: 174000, currentPrice: 192500, evaluationAmount: 962500, profitRate: 10.63, profitAmount: 92500 },
+  { tickerCode: "035420", stockName: "NAVER", stockLogo: "", quantity: 12, averageBuyPrice: 178000, currentPrice: 192000, evaluationAmount: 2304000, profitRate: 7.87, profitAmount: 168000 },
+  { tickerCode: "005380", stockName: "현대차", stockLogo: "", quantity: 8, averageBuyPrice: 225000, currentPrice: 241500, evaluationAmount: 1932000, profitRate: 7.33, profitAmount: 132000 },
+  { tickerCode: "105560", stockName: "KB금융", stockLogo: "", quantity: 35, averageBuyPrice: 81500, currentPrice: 87200, evaluationAmount: 3052000, profitRate: 9.04, profitAmount: 253000 },
+  { tickerCode: "068270", stockName: "셀트리온", stockLogo: "", quantity: 4, averageBuyPrice: 162000, currentPrice: 178500, evaluationAmount: 714000, profitRate: 10.19, profitAmount: 66000 },
+];
 
 function fmt(n: number) {
   if (Math.abs(n) >= 10000) return `${(n / 10000).toFixed(0)}만원`;
   return `${n.toLocaleString()}원`;
 }
 
+const totalAsset = 11250000;
+const totalProfit = 1250000;
+const totalProfitRate = 12.5;
+const isPositive = totalProfit >= 0;
+
 export default function AccountPage() {
-  const { data: summary } = useAccountSummaryQuery();
-  const { data: holdingsRaw = [] } = useHoldingsQuery();
-
-  const holdings = holdingsRaw.map((h) => ({
-    tickerCode: h.tickerCode,
-    stockName: h.stockName,
-    stockLogo: h.stockLogo,
-    quantity: h.quantity,
-    averageBuyPrice: h.avgPrice,
-    currentPrice: h.currentPrice,
-    evaluationAmount: h.evaluation,
-    profitRate: h.returnRate,
-    profitAmount: h.returnAmount,
-  }));
-
-  const portfolio = (summary?.holdingsRatio ?? []).map((h) => ({
-    stockName: h.stockName,
-    ratio: h.ratio,
-  }));
-
-  const totalAsset = summary?.totalAsset ?? 0;
-  const totalReturnAmount = summary?.totalReturnAmount ?? 0;
-  const totalReturnRate = summary?.totalReturnRate ?? 0;
-  const cash = summary?.cash ?? 0;
-  const initialCash = summary?.initialCash ?? 0;
-  const holdingsCount = summary?.holdingsCount ?? 0;
-  const totalEvaluation = summary?.totalEvaluation ?? 0;
-  const isPositive = totalReturnAmount >= 0;
-
   return (
     <div className="flex flex-col h-full p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
       <div>
@@ -45,39 +39,51 @@ export default function AccountPage() {
         <p className="text-[13px] text-gray-400 mt-0.5">나의 투자 현황을 한눈에 확인하세요</p>
       </div>
 
+      {/* grid: [2fr 1fr 1fr 1fr] — 상단 요약 + 하단 차트/테이블 정렬 */}
       <div className="grid grid-cols-[2fr_1fr_1fr_1fr] gap-4 items-stretch">
 
-        <SummaryCard
-          label="보유 총 자산"
-          value={fmt(totalAsset)}
-          sub={`${isPositive ? "+" : ""}${fmt(totalReturnAmount)} (${isPositive ? "+" : ""}${totalReturnRate.toFixed(2)}%)`}
-          variant="blue"
-          subColor={isPositive ? "text-red-300" : "text-blue-200"}
-        />
-        <SummaryCard
-          label="보유 현금"
-          value={fmt(cash)}
-          sub={`투자원금 ${fmt(initialCash)}`}
-        />
-        <SummaryCard
-          label="보유 종목"
-          value={`${holdingsCount}개`}
-          sub={`총 평가가 ${fmt(totalEvaluation)}`}
-        />
-        <SummaryCard
-          label="수익률"
-          value={`${isPositive ? "+" : ""}${totalReturnRate.toFixed(2)}%`}
-          sub={`${isPositive ? "+" : ""}${fmt(totalReturnAmount)}`}
-          valueColor={isPositive ? "text-red-500" : "text-blue-500"}
-          subColor={isPositive ? "text-red-400" : "text-blue-400"}
-        />
-
-        <div className="row-start-2 h-130">
-          <PortfolioChart items={portfolio} />
+        {/* 보유 총 자산 */}
+        <div className="bg-[#0046FF] rounded-2xl px-6 py-5 text-white">
+          <p className="text-[13px] font-medium opacity-80 mb-2">보유 총 자산</p>
+          <p className="text-[28px] font-bold">{fmt(totalAsset)}</p>
+          <p className={`text-[13px] font-medium mt-1 ${isPositive ? "text-red-300" : "text-blue-200"}`}>
+            {isPositive ? "+" : ""}{fmt(totalProfit)} ({isPositive ? "+" : ""}{totalProfitRate.toFixed(2)}%)
+          </p>
         </div>
 
-        <div className="col-span-3 row-start-2 h-130">
-          <HoldingList items={holdings} />
+        {/* 보유 현금 */}
+        <div className="bg-white rounded-2xl border border-gray-100 px-6 py-5">
+          <p className="text-[13px] text-gray-400 font-medium mb-2">보유 현금</p>
+          <p className="text-[22px] font-bold text-gray-900">{fmt(2140000)}</p>
+          <p className="text-[12px] text-gray-400 mt-1">투자원금 {fmt(10000000)}</p>
+        </div>
+
+        {/* 보유 종목 */}
+        <div className="bg-white rounded-2xl border border-gray-100 px-6 py-5">
+          <p className="text-[13px] text-gray-400 font-medium mb-2">보유 종목</p>
+          <p className="text-[22px] font-bold text-gray-900">6개</p>
+          <p className="text-[12px] text-gray-400 mt-1">총 평가금약 {fmt(9110000)}</p>
+        </div>
+
+        {/* 수익률 */}
+        <div className="bg-white rounded-2xl border border-gray-100 px-6 py-5">
+          <p className="text-[13px] text-gray-400 font-medium mb-2">수익률</p>
+          <p className={`text-[22px] font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+            {isPositive ? "+" : ""}{totalProfitRate.toFixed(2)}%
+          </p>
+          <p className={`text-[12px] mt-1 font-medium ${isPositive ? "text-red-400" : "text-blue-400"}`}>
+            {isPositive ? "+" : ""}{fmt(totalProfit)}
+          </p>
+        </div>
+
+        {/* 종목 비중 차트 — col 1 (2fr) */}
+        <div className="row-start-2">
+          <PortfolioChart items={DUMMY_PORTFOLIO} />
+        </div>
+
+        {/* 보유 종목 테이블 — col 2~4 (3fr) */}
+        <div className="col-span-3 row-start-2">
+          <HoldingList items={DUMMY_HOLDINGS} />
         </div>
       </div>
     </div>

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -55,15 +55,15 @@ export default function ProfilePage() {
   if (!user) return null;
 
   return (
-    <div className="flex flex-col h-full p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
+    <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50">
       {/* 헤더 */}
       <div>
         <h1 className="text-[22px] font-bold text-gray-900">내 프로필</h1>
       </div>
 
-      <div className="flex gap-5 items-start">
+      <div className="flex gap-5 flex-1 min-h-0">
         {/* 왼쪽: 프로필 카드 */}
-        <div className="w-64 shrink-0">
+        <div className="w-64 shrink-0 overflow-y-auto h-full">
           <ProfileCard
             nickname={user.nickname}
             followers={0}
@@ -79,7 +79,7 @@ export default function ProfilePage() {
         </div>
 
         {/* 오른쪽: 탭 + 콘텐츠 */}
-        <div className="flex-1 min-w-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
+        <div className="flex-1 min-w-0 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
           {/* 탭 바 */}
           <UnderlineTabBar
             tabs={[...TABS]}
@@ -88,7 +88,7 @@ export default function ProfilePage() {
           />
 
           {/* 탭 콘텐츠 */}
-          <div className={`p-5 h-[600px] ${activeTab !== "portfolio" ? "overflow-y-auto" : ""}`}>
+          <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
             {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
             {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
             {activeTab === "portfolio" && (

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import ProfileCard from "@/components/profile/ProfileCard";
+import ProfileTabs from "@/components/profile/ProfileTabs";
 
 export default function ProfilePage() {
   return (
@@ -15,7 +16,7 @@ export default function ProfilePage() {
       </div>
 
       <div className="flex-1">
-        {/* 탭 영역 — 다음 단계 */}
+        <ProfileTabs />
       </div>
     </div>
   );

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -6,11 +6,24 @@ import { authApi } from "@/api/authApi";
 import { useMyDiariesQuery } from "@/api/tradeDiaryApi";
 import { useTradeHistoryQuery } from "@/api/tradeApi";
 import { useAccountSummaryQuery, useHoldingsQuery } from "@/api/accountApi";
+import { useFollowersQuery, useFollowingQuery } from "@/api/userListApi";
 import ProfileCard from "@/components/profile/ProfileCard";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
 import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
 import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
 import PortfolioTab from "@/components/profile/PortfolioTab";
+import FollowList from "@/components/profile/FollowList";
+
+const MOCK_FOLLOWERS = [
+  { userId: 1, nickname: "투자왕김철수", imageUrl: "" },
+  { userId: 2, nickname: "주식고수박영희", imageUrl: "" },
+  { userId: 3, nickname: "강남불패이민준", imageUrl: "" },
+];
+
+const MOCK_FOLLOWING = [
+  { userId: 4, nickname: "워렌버핏팬", imageUrl: "" },
+  { userId: 5, nickname: "테슬라홀더", imageUrl: "" },
+];
 
 const TABS = [
   { id: "diary", label: "매매일지" },
@@ -26,10 +39,13 @@ export default function ProfilePage() {
   const user = useUser();
   const clearAuth = useAuthStore((s) => s.clearAuth);
   const [activeTab, setActiveTab] = useState<TabId>("diary");
+  const [followModal, setFollowModal] = useState<"followers" | "following" | null>("following");
   const { data: diaries = [] } = useMyDiariesQuery();
   const { data: tradeHistories = [] } = useTradeHistoryQuery();
   const { data: summary } = useAccountSummaryQuery();
   const { data: holdingsRaw = [] } = useHoldingsQuery();
+  const { data: followers = MOCK_FOLLOWERS } = useFollowersQuery();
+  const { data: following = MOCK_FOLLOWING } = useFollowingQuery();
 
   const holdings = holdingsRaw.map((h) => ({
     tickerCode: h.tickerCode,
@@ -63,19 +79,25 @@ export default function ProfilePage() {
 
       <div className="flex gap-5 flex-1 min-h-0">
         {/* 왼쪽: 프로필 카드 */}
-        <div className="w-64 shrink-0 overflow-y-auto h-full">
+        <div className="w-64 shrink-0 overflow-y-auto h-full flex flex-col">
           <ProfileCard
             nickname={user.nickname}
-            followers={0}
-            following={0}
-            totalReturnRate={0}
-            totalReturn={0}
+            followers={followers.length}
+            following={following.length}
+            totalReturnRate={summary?.totalReturnRate ?? 0}
+            totalReturn={summary?.totalReturnAmount ?? 0}
             onEditClick={() => {}}
             onLogoutClick={handleLogout}
             onDeleteClick={() => {}}
-            onFollowersClick={() => {}}
-            onFollowingClick={() => {}}
+            onFollowersClick={() => setFollowModal(followModal === "followers" ? null : "followers")}
+            onFollowingClick={() => setFollowModal(followModal === "following" ? null : "following")}
           />
+          {followModal && (
+            <FollowList
+              type={followModal}
+              items={followModal === "followers" ? followers : following}
+            />
+          )}
         </div>
 
         {/* 오른쪽: 탭 + 콘텐츠 */}

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -1,7 +1,22 @@
+import ProfileCard from "@/components/profile/ProfileCard";
+
 export default function ProfilePage() {
   return (
-    <div className="flex flex-col h-full p-6 bg-gray-50 min-h-screen">
-      <h1 className="text-[22px] font-bold text-gray-900">내 프로필</h1>
+    <div className="flex h-full p-6 gap-5 bg-gray-50 min-h-screen">
+      <div className="w-64 shrink-0">
+        <ProfileCard
+          nickname="투자왕김철수"
+          email="kim@example.com"
+          followerCount={42}
+          followingCount={3}
+          returnRate={12.5}
+          returnAmount={1250000}
+        />
+      </div>
+
+      <div className="flex-1">
+        {/* 탭 영역 — 다음 단계 */}
+      </div>
     </div>
   );
 }

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -13,6 +13,9 @@ import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
 import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
 import PortfolioTab from "@/components/profile/PortfolioTab";
 import FollowList from "@/components/profile/FollowList";
+import EditProfileModal from "@/components/profile/EditProfileModal";
+import DeleteAccountModal from "@/components/profile/DeleteAccountModal";
+import LogoutModal from "@/components/profile/LogoutModal";
 
 const MOCK_FOLLOWERS = [
   { userId: 1, nickname: "투자왕김철수", imageUrl: "" },
@@ -40,6 +43,7 @@ export default function ProfilePage() {
   const clearAuth = useAuthStore((s) => s.clearAuth);
   const [activeTab, setActiveTab] = useState<TabId>("diary");
   const [followModal, setFollowModal] = useState<"followers" | "following" | null>("following");
+  const [modal, setModal] = useState<"edit" | "logout" | "delete" | null>(null);
   const { data: diaries = [] } = useMyDiariesQuery();
   const { data: tradeHistories = [] } = useTradeHistoryQuery();
   const { data: summary } = useAccountSummaryQuery();
@@ -72,6 +76,22 @@ export default function ProfilePage() {
 
   return (
     <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50">
+      {modal === "edit" && (
+        <EditProfileModal
+          nickname={user.nickname}
+          onClose={() => setModal(null)}
+          onSave={(newNickname) => useAuthStore.getState().setAuth(useAuthStore.getState().accessToken!, { nickname: newNickname })}
+        />
+      )}
+      {modal === "logout" && (
+        <LogoutModal onClose={() => setModal(null)} onConfirm={handleLogout} />
+      )}
+      {modal === "delete" && (
+        <DeleteAccountModal
+          onClose={() => setModal(null)}
+          onDeleted={() => { clearAuth(); navigate("/login"); }}
+        />
+      )}
       {/* 헤더 */}
       <div>
         <h1 className="text-[22px] font-bold text-gray-900">내 프로필</h1>
@@ -86,9 +106,9 @@ export default function ProfilePage() {
             following={following.length}
             totalReturnRate={summary?.totalReturnRate ?? 0}
             totalReturn={summary?.totalReturnAmount ?? 0}
-            onEditClick={() => {}}
-            onLogoutClick={handleLogout}
-            onDeleteClick={() => {}}
+            onEditClick={() => setModal("edit")}
+            onLogoutClick={() => setModal("logout")}
+            onDeleteClick={() => setModal("delete")}
             onFollowersClick={() => setFollowModal("followers")}
             onFollowingClick={() => setFollowModal("following")}
           />

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -1,0 +1,7 @@
+export default function ProfilePage() {
+  return (
+    <div className="flex flex-col h-full p-6 bg-gray-50 min-h-screen">
+      <h1 className="text-[22px] font-bold text-gray-900">내 프로필</h1>
+    </div>
+  );
+}

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -53,9 +53,9 @@ export default function ProfilePage() {
         <h1 className="text-[22px] font-bold text-gray-900">내 프로필</h1>
       </div>
 
-      <div className="grid grid-cols-4 gap-5">
+      <div className="flex gap-5 items-start">
         {/* 왼쪽: 프로필 카드 */}
-        <div className="col-span-1">
+        <div className="w-64 shrink-0">
           <ProfileCard
             nickname={user.nickname}
             followers={0}
@@ -71,7 +71,7 @@ export default function ProfilePage() {
         </div>
 
         {/* 오른쪽: 탭 + 콘텐츠 */}
-        <div className="col-span-3 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
+        <div className="flex-1 min-w-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
           {/* 탭 바 */}
           <UnderlineTabBar
             tabs={[...TABS]}
@@ -80,7 +80,7 @@ export default function ProfilePage() {
           />
 
           {/* 탭 콘텐츠 */}
-          <div className="p-5">
+          <div className="p-5 min-h-[600px]">
             {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
             {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
             {activeTab === "portfolio" && <PortfolioTab {...DUMMY_PORTFOLIO} />}

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -88,7 +88,7 @@ export default function ProfilePage() {
           />
 
           {/* 탭 콘텐츠 */}
-          <div className="p-5 min-h-[600px]">
+          <div className={`p-5 h-[600px] ${activeTab !== "portfolio" ? "overflow-y-auto" : ""}`}>
             {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
             {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
             {activeTab === "portfolio" && (

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from "@/store/authStore";
 import { authApi } from "@/api/authApi";
 import { useMyDiariesQuery } from "@/api/tradeDiaryApi";
 import { useTradeHistoryQuery } from "@/api/tradeApi";
+import { useAccountSummaryQuery, useHoldingsQuery } from "@/api/accountApi";
 import ProfileCard from "@/components/profile/ProfileCard";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
 import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
@@ -19,13 +20,6 @@ const TABS = [
 
 type TabId = (typeof TABS)[number]["id"];
 
-const DUMMY_PORTFOLIO = {
-  totalEvaluation: 0,
-  totalReturnRate: 0,
-  totalReturnAmount: 0,
-  portfolio: [],
-  holdings: [],
-};
 
 export default function ProfilePage() {
   const navigate = useNavigate();
@@ -34,6 +28,20 @@ export default function ProfilePage() {
   const [activeTab, setActiveTab] = useState<TabId>("diary");
   const { data: diaries = [] } = useMyDiariesQuery();
   const { data: tradeHistories = [] } = useTradeHistoryQuery();
+  const { data: summary } = useAccountSummaryQuery();
+  const { data: holdingsRaw = [] } = useHoldingsQuery();
+
+  const holdings = holdingsRaw.map((h) => ({
+    tickerCode: h.tickerCode,
+    stockName: h.stockName,
+    stockLogo: h.stockLogo,
+    quantity: h.quantity,
+    averageBuyPrice: h.avgPrice,
+    currentPrice: h.currentPrice,
+    evaluationAmount: h.evaluation,
+    profitRate: h.returnRate,
+    profitAmount: h.returnAmount,
+  }));
 
   const handleLogout = async () => {
     try {
@@ -83,7 +91,15 @@ export default function ProfilePage() {
           <div className="p-5 min-h-[600px]">
             {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
             {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
-            {activeTab === "portfolio" && <PortfolioTab {...DUMMY_PORTFOLIO} />}
+            {activeTab === "portfolio" && (
+              <PortfolioTab
+                totalEvaluation={summary?.totalEvaluation ?? 0}
+                totalReturnRate={summary?.totalReturnRate ?? 0}
+                totalReturnAmount={summary?.totalReturnAmount ?? 0}
+                portfolio={summary?.holdingsRatio ?? []}
+                holdings={holdings}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -10,7 +10,6 @@ import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
 import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
 import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
 import PortfolioTab from "@/components/profile/PortfolioTab";
-import type { PortfolioData } from "@/components/profile/PortfolioTab";
 
 const TABS = [
   { id: "diary", label: "매매일지" },
@@ -20,10 +19,11 @@ const TABS = [
 
 type TabId = (typeof TABS)[number]["id"];
 
-const DUMMY_PORTFOLIO: PortfolioData = {
-  totalValue: 0,
-  totalProfitLoss: 0,
-  totalProfitLossRate: 0,
+const DUMMY_PORTFOLIO = {
+  totalEvaluation: 0,
+  totalReturnRate: 0,
+  totalReturnAmount: 0,
+  portfolio: [],
   holdings: [],
 };
 
@@ -83,7 +83,7 @@ export default function ProfilePage() {
           <div className="p-5">
             {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
             {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
-            {activeTab === "portfolio" && <PortfolioTab data={DUMMY_PORTFOLIO} />}
+            {activeTab === "portfolio" && <PortfolioTab {...DUMMY_PORTFOLIO} />}
           </div>
         </div>
       </div>

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -89,8 +89,8 @@ export default function ProfilePage() {
             onEditClick={() => {}}
             onLogoutClick={handleLogout}
             onDeleteClick={() => {}}
-            onFollowersClick={() => setFollowModal(followModal === "followers" ? null : "followers")}
-            onFollowingClick={() => setFollowModal(followModal === "following" ? null : "following")}
+            onFollowersClick={() => setFollowModal("followers")}
+            onFollowingClick={() => setFollowModal("following")}
           />
           {followModal && (
             <FollowList

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -12,6 +12,7 @@ import TradeDiaryPage from "@/pages/trade-diaries/TradeDiaryPage";
 import DiaryDetailPage from "@/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPage";
 import UserListPage from "@/pages/user-list/userListPage";
 import AccountPage from "@/pages/account/AccountPage";
+import ProfilePage from "@/pages/profile/ProfilePage";
 
 export const router = createBrowserRouter([
   {
@@ -30,6 +31,7 @@ export const router = createBrowserRouter([
             ],
           },
           { path: "account", element: <AccountPage /> },
+          { path: "profile", element: <ProfilePage /> },
           { path: "components", element: <ComponentsPage /> },
           {
             path: "trade-diary",


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #32 

## 💡 작업 배경
   - 내 프로필 페이지 레이아웃 구현 (프로필 카드 + 탭 콘텐츠)
   - 포트폴리오, 매매내역, 매매일지 탭 API 연동
   - 팔로워/팔로잉 리스트 인라인 표시
   - 프로필 편집, 로그아웃, 회원탈퇴 모달 구현
   - 보유 종목 및 매매내역 클릭 시 종목 상세 페이지로 이동
   - 프로필 카드 너비 고정으로 탭 전환 시 레이아웃 흔들림 해결

## 🧩 작업 내용
   - [ ] 프로필 카드: 팔로워/팔로잉 클릭 시 하단에 리스트 표시
   - [ ] 탭 전환 시 프로필 카드 너비 고정 유지
   - [ ] 포트폴리오 탭: 도넛 차트 및 보유 종목 목록 렌더링
   - [ ] 보유 종목 클릭 → 종목 상세 페이지 이동
   - [ ] 매매내역 클릭 → 종목 상세 페이지 이동
   - [ ] 프로필 편집 모달: 닉네임 중복확인 및 이미지 업로드
   - [ ] 로그아웃 모달: 확인 시 로그아웃 및 /login 이동
   - [ ] 회원탈퇴 모달: 비밀번호 확인 후 계정 삭제


## 📸 스크린샷(선택)

<img width="1059" height="876" alt="Screenshot 2026-03-26 at 2 58 31 PM" src="https://github.com/user-attachments/assets/b486f362-20da-42a0-ab59-a1c37485f465" />

## 📝 기타

- 추후 ui 논의 필요할 것 같습니다.
- 회원 탈퇴, 프로필 편집, 로그아웃 문구 피그마보다 좀 더 자세히 문구 출력하도록 해놓았습니다.
- ui 통일 관련해서 노션에 정리본 올려놓았습니다.
- 현재 내 팔로잉, 팔로워 api가 없어 실제 api는 연결을 못했습니다. 추후 추가 부탁드리겠습니다!