### PR TITLE
[Fix] 로고 이미지 캐싱이 아닌  api에서 가져오도록 변경

### DIFF
--- a/src/api/stockApi.ts
+++ b/src/api/stockApi.ts
@@ -32,6 +32,7 @@ export type StockItemMessage = {
 export type StockQuote = {
   stockCode: string;
   stockName: string;
+  stockLogo: string;
   currentPrice: number;
   changePrice: number; // 전일 대비
   changeRate: number; // 등락률 (%)

--- a/src/pages/stocks/[stockId]/StockDetailPage.tsx
+++ b/src/pages/stocks/[stockId]/StockDetailPage.tsx
@@ -119,7 +119,7 @@ export default function StockDetailPage() {
   const headerStock = {
     tickerCode: quote.stockCode,
     stockName: quote.stockName,
-    stockLogo: selectedStock?.stockLogo ?? "",
+    stockLogo: quote.stockLogo,
     sectorType: selectedStock?.sectorType ?? "",
     currentPrice: quote.currentPrice,
     change: quote.changePrice,


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #44 

## 💡 작업 배경
  - 종목 상세 페이지 새로고침 시 로고 이미지가 표시되지 않는 버그 발생               
                                                        

## 🧩 작업 내용

  - 종목 상세 페이지 새로고침 시 로고 이미지가 표시되지 않는 버그 수정
  - 기존: zustand store(selectedStock)에서 stockLogo를 가져와 새로고침 시 null이
   되는 문제                                                                    
  - 변경: quote API 응답에서 직접 stockLogo를 사용하도록 수정                   
  - StockQuote 타입에 stockLogo 필드 추가                    
                                                        
## 📸 스크린샷(선택)
<img width="1317" height="848" alt="Screenshot 2026-03-26 at 4 59 15 PM" src="https://github.com/user-attachments/assets/6dd98dc1-d4a2-45de-b0af-3dbbd3d95761" />


## 📝 기타