### PR TITLE
[Feat] 내 프로필 실데이터 연동 및 UI 수정  

### DIFF
--- a/src/api/userListApi.ts
+++ b/src/api/userListApi.ts
@@ -101,6 +101,27 @@ export function useUserListCacheUpdate() {
   return { toggleFollow, setMentoringStatus };
 }
 
+// ─── My Profile ───────────────────────────────────────────────────────────────
+
+export type MyProfile = {
+  userId: number;
+  nickname: string;
+  imageUrl: string;
+  followerCount: number;
+  followingCount: number;
+};
+
+export function useMyProfileQuery() {
+  return useQuery({
+    queryKey: ["users", "me"],
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<MyProfile>>("/api/users/me")
+        .then((res) => res.data),
+    staleTime: 30_000,
+  });
+}
+
 // ─── Follow List Types ────────────────────────────────────────────────────────
 
 export type FollowUser = {
@@ -111,13 +132,19 @@ export type FollowUser = {
 
 // ─── Follow List Hooks ────────────────────────────────────────────────────────
 
+type FollowListData = {
+  users: FollowUser[];
+  nextCursor: number | null;
+  hasNext: boolean;
+};
+
 export function useFollowersQuery() {
   return useQuery({
     queryKey: ["follows", "followers"],
     queryFn: () =>
       fetchClient
-        .get<ApiResponse<FollowUser[]>>("/api/follows/followers")
-        .then((res) => res.data),
+        .get<ApiResponse<FollowListData>>("/api/users/me/followers")
+        .then((res) => res.data.users),
   });
 }
 
@@ -126,8 +153,8 @@ export function useFollowingQuery() {
     queryKey: ["follows", "following"],
     queryFn: () =>
       fetchClient
-        .get<ApiResponse<FollowUser[]>>("/api/follows/following")
-        .then((res) => res.data),
+        .get<ApiResponse<FollowListData>>("/api/users/me/following")
+        .then((res) => res.data.users),
   });
 }
 

--- a/src/api/userListApi.ts
+++ b/src/api/userListApi.ts
@@ -138,23 +138,33 @@ type FollowListData = {
   hasNext: boolean;
 };
 
-export function useFollowersQuery() {
-  return useQuery({
+export function useFollowersInfiniteQuery() {
+  return useInfiniteQuery({
     queryKey: ["follows", "followers"],
-    queryFn: () =>
-      fetchClient
-        .get<ApiResponse<FollowListData>>("/api/users/me/followers")
-        .then((res) => res.data.users),
+    queryFn: ({ pageParam }) => {
+      const params = pageParam !== undefined ? `?cursor=${pageParam}` : "";
+      return fetchClient
+        .get<ApiResponse<FollowListData>>(`/api/users/me/followers${params}`)
+        .then((res) => res.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
   });
 }
 
-export function useFollowingQuery() {
-  return useQuery({
+export function useFollowingInfiniteQuery() {
+  return useInfiniteQuery({
     queryKey: ["follows", "following"],
-    queryFn: () =>
-      fetchClient
-        .get<ApiResponse<FollowListData>>("/api/users/me/following")
-        .then((res) => res.data.users),
+    queryFn: ({ pageParam }) => {
+      const params = pageParam !== undefined ? `?cursor=${pageParam}` : "";
+      return fetchClient
+        .get<ApiResponse<FollowListData>>(`/api/users/me/following${params}`)
+        .then((res) => res.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
   });
 }
 

--- a/src/components/profile/EditProfileModal.tsx
+++ b/src/components/profile/EditProfileModal.tsx
@@ -30,17 +30,19 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
   };
 
   const handleCheckNickname = async () => {
-    if (!nicknameValue.trim() || nicknameValue === nickname) {
-      setNicknameChecked(true);
-      return;
-    }
+    if (!nicknameValue.trim()) return;
     setChecking(true);
     try {
-      await fetchClient.get<ApiResponse<void>>("/api/auth/nickname/check", { nickname: nicknameValue });
+      await fetchClient.get<ApiResponse<void>>("/api/users/nickname/check", { nickname: nicknameValue });
       setNicknameChecked(true);
       setNicknameMsg({ text: "사용 가능한 닉네임이에요.", ok: true });
-    } catch {
-      setNicknameMsg({ text: "이미 사용 중인 닉네임이에요.", ok: false });
+    } catch (err: unknown) {
+      const msg = (err as Error)?.message ?? "";
+      if (msg.includes("400")) {
+        setNicknameMsg({ text: "현재 사용 중인 닉네임이에요.", ok: false });
+      } else {
+        setNicknameMsg({ text: "이미 다른 사람이 사용 중인 닉네임이에요.", ok: false });
+      }
     } finally {
       setChecking(false);
     }
@@ -78,10 +80,10 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
     }
   };
 
+  const nicknameUnchanged = nicknameValue === nickname;
   const canSave =
     nicknameValue.trim() &&
-    (nicknameValue === nickname || nicknameChecked) &&
-    nicknameMsg?.ok !== false;
+    (nicknameUnchanged || (nicknameChecked && nicknameMsg?.ok !== false));
 
   const displayImage = imagePreview ?? profileImageUrl ?? undefined;
 

--- a/src/components/profile/EditProfileModal.tsx
+++ b/src/components/profile/EditProfileModal.tsx
@@ -98,15 +98,35 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
 
         <div className="px-6 py-6 flex flex-col gap-5">
           {/* 프로필 이미지 */}
-          <div className="flex justify-center">
+          <div className="flex flex-col items-center gap-2">
             <button
-              className="relative group"
+              className="relative group shrink-0"
+              style={{ width: 80, height: 80 }}
               onClick={() => fileRef.current?.click()}
             >
-              <Avatar name={nicknameValue} src={displayImage} size={80} />
-              <div className="absolute inset-0 rounded-full bg-black/30 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                <Camera size={20} className="text-white" />
+              {/* 원형 클리핑 컨테이너 */}
+              <div style={{ width: 80, height: 80, borderRadius: "50%", overflow: "hidden", position: "relative" }}>
+                {displayImage ? (
+                  <img
+                    src={displayImage}
+                    alt="프로필"
+                    style={{ width: 80, height: 80, objectFit: "cover", display: "block" }}
+                  />
+                ) : (
+                  <Avatar name={nicknameValue} size={80} />
+                )}
+                <div className="absolute inset-0 bg-black/25 opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
+              {/* 카메라 배지 */}
+              <div className="absolute bottom-0 right-0 w-6 h-6 bg-[#0046FF] rounded-full flex items-center justify-center border-2 border-white">
+                <Camera size={11} className="text-white" />
+              </div>
+            </button>
+            <button
+              onClick={() => fileRef.current?.click()}
+              className="text-[12px] text-[#0046FF] font-medium hover:underline"
+            >
+              사진 변경
             </button>
             <input ref={fileRef} type="file" accept="image/*" className="hidden" onChange={handleImageChange} />
           </div>

--- a/src/components/profile/FollowList.tsx
+++ b/src/components/profile/FollowList.tsx
@@ -1,19 +1,44 @@
+import { useEffect, useRef } from "react";
 import Avatar from "@/components/ui/Avatar";
-import type { FollowUser } from "@/api/userListApi";
+import {
+  useFollowersInfiniteQuery,
+  useFollowingInfiniteQuery,
+} from "@/api/userListApi";
 
 type Props = {
   type: "followers" | "following";
-  items: FollowUser[];
 };
 
 const LABEL = { followers: "팔로워", following: "팔로잉" };
 
-export default function FollowList({ type, items }: Props) {
+export default function FollowList({ type }: Props) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const followersQuery = useFollowersInfiniteQuery();
+  const followingQuery = useFollowingInfiniteQuery();
+  const query = type === "followers" ? followersQuery : followingQuery;
+
+  const items = query.data?.pages.flatMap((p) => p.users) ?? [];
+
+  useEffect(() => {
+    if (!bottomRef.current) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && query.hasNextPage && !query.isFetchingNextPage) {
+          query.fetchNextPage();
+        }
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(bottomRef.current);
+    return () => observer.disconnect();
+  }, [query]);
+
   return (
     <div className="bg-white rounded-2xl border border-gray-100 mt-3 flex-1 overflow-y-auto">
       <p className="text-[13px] font-semibold text-gray-700 px-4 pt-4 pb-2">{LABEL[type]}</p>
-      {items.length === 0 ? (
-        <div className="flex-1 flex items-center justify-center py-10">
+      {items.length === 0 && !query.isLoading ? (
+        <div className="flex items-center justify-center py-10">
           <p className="text-[12px] text-gray-400">{LABEL[type]}이 없습니다.</p>
         </div>
       ) : (
@@ -27,6 +52,7 @@ export default function FollowList({ type, items }: Props) {
               <span className="text-[13px] font-medium text-gray-800">{user.nickname}</span>
             </div>
           ))}
+          <div ref={bottomRef} className="h-1" />
         </div>
       )}
     </div>

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -40,9 +40,9 @@ export default function Avatar({
         src={src}
         alt={name}
         onClick={onClick}
-        style={{ width: `${size}px` }}
+        style={{ width: `${size}px`, height: `${size}px` }}
         className={[
-          "rounded-full flex items-center justify-center shrink-0 select-none object-cover",
+          "rounded-full flex items-center justify-center shrink-0 select-none object-cover overflow-hidden",
           onClick ? "cursor-pointer" : "",
           className,
         ].join(" ")}

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -6,7 +6,7 @@ import { authApi } from "@/api/authApi";
 import { useMyDiariesQuery } from "@/api/tradeDiaryApi";
 import { useTradeHistoryQuery } from "@/api/tradeApi";
 import { useAccountSummaryQuery, useHoldingsQuery } from "@/api/accountApi";
-import { useFollowersQuery, useFollowingQuery } from "@/api/userListApi";
+import { useMyProfileQuery } from "@/api/userListApi";
 import ProfileCard from "@/components/profile/ProfileCard";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
 import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
@@ -16,17 +16,6 @@ import FollowList from "@/components/profile/FollowList";
 import EditProfileModal from "@/components/profile/EditProfileModal";
 import DeleteAccountModal from "@/components/profile/DeleteAccountModal";
 import LogoutModal from "@/components/profile/LogoutModal";
-
-const MOCK_FOLLOWERS = [
-  { userId: 1, nickname: "투자왕김철수", imageUrl: "" },
-  { userId: 2, nickname: "주식고수박영희", imageUrl: "" },
-  { userId: 3, nickname: "강남불패이민준", imageUrl: "" },
-];
-
-const MOCK_FOLLOWING = [
-  { userId: 4, nickname: "워렌버핏팬", imageUrl: "" },
-  { userId: 5, nickname: "테슬라홀더", imageUrl: "" },
-];
 
 const TABS = [
   { id: "diary", label: "매매일지" },
@@ -46,12 +35,11 @@ export default function ProfilePage() {
   const [activeTab, setActiveTab] = useState<TabId>(initialTab);
   const [followModal, setFollowModal] = useState<"followers" | "following" | null>("following");
   const [modal, setModal] = useState<"edit" | "logout" | "delete" | null>(null);
+  const { data: myProfile } = useMyProfileQuery();
   const { data: diaries = [] } = useMyDiariesQuery();
   const { data: tradeHistories = [] } = useTradeHistoryQuery();
   const { data: summary } = useAccountSummaryQuery();
   const { data: holdingsRaw = [] } = useHoldingsQuery();
-  const { data: followers = MOCK_FOLLOWERS } = useFollowersQuery();
-  const { data: following = MOCK_FOLLOWING } = useFollowingQuery();
 
   const holdings = holdingsRaw.map((h) => ({
     tickerCode: h.tickerCode,
@@ -80,7 +68,8 @@ export default function ProfilePage() {
     <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50">
       {modal === "edit" && (
         <EditProfileModal
-          nickname={user.nickname}
+          nickname={myProfile?.nickname ?? user.nickname}
+          profileImageUrl={myProfile?.imageUrl}
           onClose={() => setModal(null)}
           onSave={(newNickname) => useAuthStore.getState().setAuth(useAuthStore.getState().accessToken!, { nickname: newNickname })}
         />
@@ -103,9 +92,10 @@ export default function ProfilePage() {
         {/* 왼쪽: 프로필 카드 */}
         <div className="w-64 shrink-0 overflow-y-auto h-full flex flex-col">
           <ProfileCard
-            nickname={user.nickname}
-            followers={followers.length}
-            following={following.length}
+            nickname={myProfile?.nickname ?? user.nickname}
+            profileImageUrl={myProfile?.imageUrl}
+            followers={myProfile?.followerCount ?? 0}
+            following={myProfile?.followingCount ?? 0}
             totalReturnRate={summary?.totalReturnRate ?? 0}
             totalReturn={summary?.totalReturnAmount ?? 0}
             onEditClick={() => setModal("edit")}
@@ -115,10 +105,7 @@ export default function ProfilePage() {
             onFollowingClick={() => setFollowModal("following")}
           />
           {followModal && (
-            <FollowList
-              type={followModal}
-              items={followModal === "followers" ? followers : following}
-            />
+            <FollowList type={followModal} />
           )}
         </div>
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #50

## 💡 작업 배경
- 닉네임 중복 확인 로직 정교화를 위해 현재 닉네임인 경우 문구 표시가 필요했다.
- api 연동 필요
  - GET /api/users/me 연동으로 닉네임, 프로필 이미지, 팔로워/팔로잉 수 실데이터
  표시                                                                          
  - 팔로워/팔로잉 목록 GET /api/users/me/followers|following 연동 및 무한스크롤 
  적용                                                                         
  - 프로필 편집 모달 이미지 원형 클리핑 수정 (Avatar height 누락 + inline style 
  적용)                                                                        
  - 닉네임 중복확인 엔드포인트 /api/users/nickname/check 로 변경                
    - 400 → "현재 사용 중인 닉네임이에요"                       
    - 409 → "이미 다른 사람이 사용 중인 닉네임이에요"                           
  - 이미지만 변경 시 닉네임 중복확인 없이 저장 가능하도록 수정  

## 🧩 작업 내용
  -  프로필 카드에 실제 닉네임, 이미지, 팔로워/팔로잉 수 표시                
  -  팔로워/팔로잉 탭 클릭 시 목록 표시 및 스크롤 시 추가 로드               
  - 프로필 편집 모달 이미지 원형으로 표시                                   
  - 현재 닉네임 입력 후 중복확인 → "현재 사용 중인 닉네임이에요"            
  - 타인 닉네임 입력 후 중복확인 → "이미 다른 사람이 사용 중인 닉네임이에요"
  - 이미지만 변경 시 닉네임 중복확인 없이 저장 가능 

## 📸 스크린샷(선택)
<img width="713" height="650" alt="Screenshot 2026-03-26 at 5 50 15 PM" src="https://github.com/user-attachments/assets/91f435fa-ac08-48c8-9217-0310f2305af0" />
<img width="1340" height="874" alt="Screenshot 2026-03-26 at 5 50 26 PM" src="https://github.com/user-attachments/assets/e348b2d5-38c8-4cdf-91c9-4c06b17eb0be" />


## 📝 기타