### PR TITLE
[Feat] 종목 상세 페이지 브라우저 탭 실시간 주가 표시

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>SOLMATE</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/stocks/[stockId]/StockDetailPage.tsx
+++ b/src/pages/stocks/[stockId]/StockDetailPage.tsx
@@ -100,6 +100,29 @@ export default function StockDetailPage() {
     };
   }, [stockCode, queryClient]);
 
+  // ── 브라우저 탭 제목 실시간 업데이트 ────────────────────────────────────
+  useEffect(() => {
+    if (!quote) return;
+    const rate = quote.changeRate;
+    document.title = `${quote.currentPrice.toLocaleString()}원 ${rate > 0 ? "+" : ""}${rate.toFixed(2)}% | ${quote.stockName}`;
+
+    const setFavicon = (href: string) => {
+      const existing = document.querySelector("link[rel='icon']");
+      if (existing) existing.remove();
+      const link = document.createElement("link");
+      link.rel = "icon";
+      link.href = href;
+      document.head.appendChild(link);
+    };
+
+    if (quote.stockLogo) setFavicon(quote.stockLogo);
+
+    return () => {
+      document.title = "SOLMATE";
+      setFavicon("/vite.svg");
+    };
+  }, [quote]);
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-full min-h-screen">


### PR DESCRIPTION
## #️⃣  관련 이슈
  closed #54
                                                                                                                
  ## 💡 작업 배경
  종목 상세 페이지 진입 시 브라우저 탭에 현재 주가와 등락률이 표시되면 사용자가 다른 탭을 보면서도 실시간 주가를
   확인할 수 있어 UX가 개선됩니다.                                                                              
   
  ## 🧩 작업 내용                                                                                               
  - 종목 상세 진입 시 브라우저 탭 제목을 `현재가 등락률 | 종목명` 형식으로 변경
  - STOMP 실시간 데이터 수신 시 탭 제목 자동 갱신                                                               
  - 종목 로고를 브라우저 탭 favicon으로 교체
  - 종목 상세 이탈 시 탭 제목(`SOLMATE`) 및 favicon 원래대로 복구                                               
  - 기본 탭 제목 `Vite + React + TS` → `SOLMATE` 로 변경                                                        
                                                                                                                
  ## 📸 스크린샷(선택) 
<img width="165" height="47" alt="image" src="https://github.com/user-attachments/assets/ac71e51c-5dd4-4eef-a26f-990f38715099" />
                                                                                       
                                                                                                                
  ## 📝 기타