### PR TITLE
[Feat] 알림 페이지 구현 및 API 연결

### DIFF
--- a/src/api/notificationApi.ts
+++ b/src/api/notificationApi.ts
@@ -1,0 +1,99 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { fetchClient } from "@/lib/fetchClient";
+import type { ApiResponse } from "./authApi";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type NotificationType =
+  | "FOLLOW"
+  | "MENTORING_REQUEST"
+  | "MENTORING_ACCEPTED"
+  | "MENTORING_REJECTED"
+  | "COMMENT"
+  | "TRADE";
+
+export type NotificationCategory = "SOCIAL" | "TRADING" | "MENTORING";
+
+export type NotificationItem = {
+  notificationId: number;
+  notificationType: NotificationType;
+  category: NotificationCategory;
+  content: string;
+  isRead: boolean;
+  actUrl: string;
+  createdAt: string;
+};
+
+export type NotificationCountResponse = {
+  total: number;
+  social: number;
+  trading: number;
+  mentoring: number;
+};
+
+// ─── Query Keys ───────────────────────────────────────────────────────────────
+
+export const notificationQueryKeys = {
+  list: ["notifications"] as const,
+  unreadCount: ["notifications", "unread-count"] as const,
+};
+
+// ─── Hooks ────────────────────────────────────────────────────────────────────
+
+export function useNotificationsQuery() {
+  return useQuery({
+    queryKey: notificationQueryKeys.list,
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<NotificationItem[]>>("/api/notifications")
+        .then((res) => res.data),
+    staleTime: 30_000,
+  });
+}
+
+export function useUnreadCountQuery() {
+  return useQuery({
+    queryKey: notificationQueryKeys.unreadCount,
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<NotificationCountResponse>>("/api/notifications/unread-count")
+        .then((res) => res.data),
+    staleTime: 30_000,
+  });
+}
+
+export function useMarkReadMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (notificationId: number) =>
+      fetchClient.patch(`/api/notifications/${notificationId}/read`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.list });
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.unreadCount });
+    },
+  });
+}
+
+export function useAcceptMentorMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (notificationId: number) =>
+      fetchClient.post(`/api/notifications/${notificationId}/mentor-request/accept`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.list });
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.unreadCount });
+    },
+  });
+}
+
+export function useRejectMentorMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (notificationId: number) =>
+      fetchClient.post(`/api/notifications/${notificationId}/mentor-request/reject`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.list });
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.unreadCount });
+    },
+  });
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
 import Logo from "../ui/Logo";
 import { useAuthStore } from "@/store/authStore";
 import { authApi } from "@/api/authApi";
+import { useUnreadCountQuery } from "@/api/notificationApi";
 
 export type NavItemConfig = {
   id: string;
@@ -182,6 +183,7 @@ export default function SidebarNav() {
 
   const storeUser = useAuthStore((s) => s.user);
   const clearAuth = useAuthStore((s) => s.clearAuth);
+  const { data: unreadCount } = useUnreadCountQuery();
 
   const user = storeUser
     ? { name: storeUser.nickname, returnRate: "-", avatarColor: "#0046FF" }
@@ -196,6 +198,12 @@ export default function SidebarNav() {
     }
   };
 
+  const navItems = NAV_ITEMS.map((item) =>
+    item.id === "notifications"
+      ? { ...item, badge: unreadCount?.total ?? 0 }
+      : item
+  );
+
   return (
     <nav className="w-64 h-screen sticky top-0 bg-white border-r border-gray-100 flex flex-col py-5 shrink-0 overflow-y-auto">
       <div className="px-4 pb-2">
@@ -203,7 +211,7 @@ export default function SidebarNav() {
       </div>
       <div className="mx-4 my-3 h-px bg-gray-100" />
       <ul className="flex flex-col gap-0.5 px-2.5 list-none">
-        {NAV_ITEMS.map((item) => (
+        {navItems.map((item) => (
           <NavItem
             key={item.id}
             item={item}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -45,7 +45,7 @@ const NAV_ITEMS: NavItemConfig[] = [
   { id: "account", label: "내 계좌", icon: Wallet, href: "/account" },
   { id: "trade", label: "매매일지", icon: BookOpen, href: "/trade-diary" },
   { id: "users", label: "유저 목록", icon: Users, href: "/users" },
-  { id: "alarm", label: "알림", icon: Bell, href: "/alarm" },
+  { id: "notifications", label: "알림", icon: Bell, href: "/notifications" },
   { id: "mentor", label: "나의 멘토", icon: GraduationCap, href: "/mentor" },
   { id: "mentee", label: "나의 멘티", icon: UserCheck, href: "/mentee" },
   { id: "profile", label: "프로필", icon: UserCircle, href: "/profile" },

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -1,0 +1,131 @@
+import { Bell, Users, Zap, CheckCircle, XCircle } from "lucide-react";
+import type { NotificationItem } from "@/api/notificationApi";
+
+type Props = {
+  item: NotificationItem;
+  onAccept?: (id: number) => void;
+  onReject?: (id: number) => void;
+};
+
+function timeAgo(createdAt: string) {
+  const diff = Date.now() - new Date(createdAt).getTime();
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return "방금 전";
+  if (min < 60) return `${min}분 전`;
+  const hour = Math.floor(min / 60);
+  if (hour < 24) return `${hour}시간 전`;
+  const day = Math.floor(hour / 24);
+  return `${day}일 전`;
+}
+
+type IconConfig = {
+  bg: string;
+  icon: React.ReactNode;
+  badgeText: string;
+  badgeClass: string;
+};
+
+function getIconConfig(type: NotificationItem["notificationType"]): IconConfig {
+  switch (type) {
+    case "MENTORING_REQUEST":
+      return {
+        bg: "bg-yellow-100",
+        icon: <Bell size={18} className="text-yellow-500" />,
+        badgeText: "멘토 신청",
+        badgeClass: "text-yellow-600 bg-yellow-50",
+      };
+    case "MENTORING_ACCEPTED":
+      return {
+        bg: "bg-green-50",
+        icon: <CheckCircle size={18} className="text-green-500" />,
+        badgeText: "멘토 수락",
+        badgeClass: "text-green-600 bg-green-50",
+      };
+    case "MENTORING_REJECTED":
+      return {
+        bg: "bg-red-50",
+        icon: <XCircle size={18} className="text-red-400" />,
+        badgeText: "멘토 거절",
+        badgeClass: "text-red-500 bg-red-50",
+      };
+    case "TRADE":
+      return {
+        bg: "bg-orange-50",
+        icon: <Zap size={18} className="text-orange-500" />,
+        badgeText: "주문 체결",
+        badgeClass: "text-orange-600 bg-orange-50",
+      };
+    case "FOLLOW":
+    case "COMMENT":
+    default:
+      return {
+        bg: "bg-blue-50",
+        icon: <Users size={18} className="text-[#0046FF]" />,
+        badgeText: type === "FOLLOW" ? "팔로우 거래 알림" : "알림",
+        badgeClass: "text-blue-600 bg-blue-50",
+      };
+  }
+}
+
+export default function NotificationCard({ item, onAccept, onReject }: Props) {
+  const { bg, icon, badgeText, badgeClass } = getIconConfig(item.notificationType);
+  const isUnread = !item.isRead;
+
+  return (
+    <div
+      className={`rounded-2xl border p-5 shadow-sm ${
+        isUnread ? "bg-white border-blue-200" : "bg-white border-gray-100"
+      }`}
+    >
+      <div className="flex items-start gap-4">
+        {/* 아이콘 */}
+        <div
+          className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 ${bg} ${
+            !isUnread ? "opacity-60" : ""
+          }`}
+        >
+          {icon}
+        </div>
+
+        {/* 내용 */}
+        <div className="flex-1 min-w-0">
+          {/* 뱃지 + 읽음 점 + 시간 */}
+          <div className="flex items-start justify-between gap-2 mb-1">
+            <div className="flex items-center gap-1.5">
+              <span className={`text-[12px] font-semibold px-2 py-0.5 rounded-md ${isUnread ? badgeClass : "text-gray-400 bg-gray-100"}`}>
+                {badgeText}
+              </span>
+              {isUnread && (
+                <span className="w-2 h-2 rounded-full bg-[#0046FF] inline-block" />
+              )}
+            </div>
+            <span className="text-[12px] text-gray-400 shrink-0">{timeAgo(item.createdAt)}</span>
+          </div>
+
+          {/* 메시지 */}
+          <p className={`text-[14px] font-medium mt-1.5 ${isUnread ? "text-gray-800" : "text-gray-500"}`}>
+            {item.content}
+          </p>
+
+          {/* 멘토 신청 액션 버튼 */}
+          {item.notificationType === "MENTORING_REQUEST" && isUnread && (
+            <div className="flex items-center gap-2 mt-3">
+              <button
+                onClick={() => onAccept?.(item.notificationId)}
+                className="px-3 py-1.5 text-[12px] font-semibold text-white bg-green-500 hover:bg-green-600 rounded-lg cursor-pointer transition-colors"
+              >
+                수락
+              </button>
+              <button
+                onClick={() => onReject?.(item.notificationId)}
+                className="px-3 py-1.5 text-[12px] font-semibold text-white bg-red-500 hover:bg-red-600 rounded-lg cursor-pointer transition-colors"
+              >
+                거절
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -3,6 +3,7 @@ import type { NotificationItem } from "@/api/notificationApi";
 
 type Props = {
   item: NotificationItem;
+  onRead?: (id: number) => void;
   onAccept?: (id: number) => void;
   onReject?: (id: number) => void;
 };
@@ -67,13 +68,18 @@ function getIconConfig(type: NotificationItem["notificationType"]): IconConfig {
   }
 }
 
-export default function NotificationCard({ item, onAccept, onReject }: Props) {
+export default function NotificationCard({ item, onRead, onAccept, onReject }: Props) {
   const { bg, icon, badgeText, badgeClass } = getIconConfig(item.notificationType);
   const isUnread = !item.isRead;
 
+  const handleClick = () => {
+    if (isUnread) onRead?.(item.notificationId);
+  };
+
   return (
     <div
-      className={`rounded-2xl border p-5 shadow-sm ${
+      onClick={handleClick}
+      className={`rounded-2xl border p-5 shadow-sm cursor-pointer ${
         isUnread ? "bg-white border-blue-200" : "bg-white border-gray-100"
       }`}
     >

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -41,74 +41,78 @@ export default function NotificationPage() {
   };
 
   return (
-    <div className="flex flex-col p-6 gap-5 bg-gray-50 min-h-screen max-w-3xl">
-      {/* 헤더 */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Bell size={22} className="text-[#0046FF]" />
-          <div>
-            <h1 className="text-[22px] font-bold text-gray-900">알림</h1>
-            {totalUnread > 0 && (
-              <p className="text-[13px] text-gray-400">읽지 않은 알림 {totalUnread}개</p>
-            )}
-          </div>
-        </div>
-        {totalUnread > 0 && (
-          <button
-            onClick={handleMarkAllRead}
-            className="text-[13px] text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
-          >
-            모두 읽음
-          </button>
-        )}
-      </div>
-
-      {/* 카테고리 탭 */}
-      <div className="flex gap-2">
-        {TABS.map((tab) => {
-          const isActive = activeTab === tab.id;
-          const count = tab.countKey ? (unreadCount?.[tab.countKey] ?? 0) : 0;
-          return (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold rounded-xl cursor-pointer transition-colors ${
-                isActive
-                  ? "bg-[#0046FF] text-white"
-                  : "bg-white text-gray-600 border border-gray-200 hover:bg-gray-50"
-              }`}
-            >
-              {tab.label}
-              {count > 0 && (
-                <span
-                  className={`flex items-center justify-center rounded-full text-[11px] font-bold w-[18px] h-[18px] ${
-                    isActive ? "bg-white text-[#0046FF]" : "bg-red-500 text-white"
-                  }`}
-                >
-                  {count}
-                </span>
+    <div className="flex flex-col h-screen bg-gray-50">
+      {/* 헤더 + 탭 (고정) */}
+      <div className="flex flex-col gap-4 p-6 pb-4 shrink-0">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Bell size={22} className="text-[#0046FF]" />
+            <div>
+              <h1 className="text-[22px] font-bold text-gray-900">알림</h1>
+              {totalUnread > 0 && (
+                <p className="text-[13px] text-gray-400">읽지 않은 알림 {totalUnread}개</p>
               )}
+            </div>
+          </div>
+          {totalUnread > 0 && (
+            <button
+              onClick={handleMarkAllRead}
+              className="text-[13px] text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+            >
+              모두 읽음
             </button>
-          );
-        })}
+          )}
+        </div>
+
+        {/* 카테고리 탭 */}
+        <div className="flex gap-2">
+          {TABS.map((tab) => {
+            const isActive = activeTab === tab.id;
+            const count = tab.countKey ? (unreadCount?.[tab.countKey] ?? 0) : 0;
+            return (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold rounded-xl cursor-pointer transition-colors ${
+                  isActive
+                    ? "bg-[#0046FF] text-white"
+                    : "bg-white text-gray-600 border border-gray-200 hover:bg-gray-50"
+                }`}
+              >
+                {tab.label}
+                {count > 0 && (
+                  <span
+                    className={`flex items-center justify-center rounded-full text-[11px] font-bold w-[18px] h-[18px] ${
+                      isActive ? "bg-white text-[#0046FF]" : "bg-red-500 text-white"
+                    }`}
+                  >
+                    {count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      {/* 알림 리스트 */}
-      <div className="flex flex-col gap-3">
-        {filtered.length === 0 ? (
-          <div className="flex items-center justify-center py-16 text-[14px] text-gray-400">
-            알림이 없습니다.
-          </div>
-        ) : (
-          filtered.map((item) => (
-            <NotificationCard
-              key={item.notificationId}
-              item={item}
-              onAccept={(id) => acceptMentor.mutate(id)}
-              onReject={(id) => rejectMentor.mutate(id)}
-            />
-          ))
-        )}
+      {/* 알림 리스트 (스크롤) */}
+      <div className="flex-1 overflow-y-auto px-6 pb-6">
+        <div className="flex flex-col gap-3">
+          {filtered.length === 0 ? (
+            <div className="flex items-center justify-center py-16 text-[14px] text-gray-400">
+              알림이 없습니다.
+            </div>
+          ) : (
+            filtered.map((item) => (
+              <NotificationCard
+                key={item.notificationId}
+                item={item}
+                onAccept={(id) => acceptMentor.mutate(id)}
+                onReject={(id) => rejectMentor.mutate(id)}
+              />
+            ))
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -24,9 +24,9 @@ export default function NotificationPage() {
 
   const { data: notifications = [] } = useNotificationsQuery();
   const { data: unreadCount } = useUnreadCountQuery();
-  const markRead = useMarkReadMutation();
   const acceptMentor = useAcceptMentorMutation();
   const rejectMentor = useRejectMentorMutation();
+  const markRead = useMarkReadMutation();
 
   const filtered = activeTab === "all"
     ? notifications
@@ -34,34 +34,18 @@ export default function NotificationPage() {
 
   const totalUnread = unreadCount?.total ?? 0;
 
-  const handleMarkAllRead = () => {
-    notifications
-      .filter((n) => !n.isRead)
-      .forEach((n) => markRead.mutate(n.notificationId));
-  };
-
   return (
     <div className="flex flex-col h-screen bg-gray-50">
       {/* 헤더 + 탭 (고정) */}
       <div className="flex flex-col gap-4 p-6 pb-4 shrink-0">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Bell size={22} className="text-[#0046FF]" />
-            <div>
-              <h1 className="text-[22px] font-bold text-gray-900">알림</h1>
-              {totalUnread > 0 && (
-                <p className="text-[13px] text-gray-400">읽지 않은 알림 {totalUnread}개</p>
-              )}
-            </div>
+        <div className="flex items-center gap-3">
+          <Bell size={22} className="text-[#0046FF]" />
+          <div>
+            <h1 className="text-[22px] font-bold text-gray-900">알림</h1>
+            {totalUnread > 0 && (
+              <p className="text-[13px] text-gray-400">읽지 않은 알림 {totalUnread}개</p>
+            )}
           </div>
-          {totalUnread > 0 && (
-            <button
-              onClick={handleMarkAllRead}
-              className="text-[13px] text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
-            >
-              모두 읽음
-            </button>
-          )}
         </div>
 
         {/* 카테고리 탭 */}
@@ -107,6 +91,7 @@ export default function NotificationPage() {
               <NotificationCard
                 key={item.notificationId}
                 item={item}
+                onRead={(id) => markRead.mutate(id)}
                 onAccept={(id) => acceptMentor.mutate(id)}
                 onReject={(id) => rejectMentor.mutate(id)}
               />

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { Bell } from "lucide-react";
+import {
+  useNotificationsQuery,
+  useUnreadCountQuery,
+  useMarkReadMutation,
+  useAcceptMentorMutation,
+  useRejectMentorMutation,
+} from "@/api/notificationApi";
+import type { NotificationCategory } from "@/api/notificationApi";
+import NotificationCard from "@/components/notification/NotificationCard";
+
+type TabId = "all" | NotificationCategory;
+
+const TABS: { id: TabId; label: string; countKey?: keyof { total: number; social: number; trading: number; mentoring: number } }[] = [
+  { id: "all", label: "전체", countKey: "total" },
+  { id: "MENTORING", label: "멘토신청", countKey: "mentoring" },
+  { id: "TRADING", label: "주문체결", countKey: "trading" },
+  { id: "SOCIAL", label: "팔로우", countKey: "social" },
+];
+
+export default function NotificationPage() {
+  const [activeTab, setActiveTab] = useState<TabId>("all");
+
+  const { data: notifications = [] } = useNotificationsQuery();
+  const { data: unreadCount } = useUnreadCountQuery();
+  const markRead = useMarkReadMutation();
+  const acceptMentor = useAcceptMentorMutation();
+  const rejectMentor = useRejectMentorMutation();
+
+  const filtered = activeTab === "all"
+    ? notifications
+    : notifications.filter((n) => n.category === activeTab);
+
+  const totalUnread = unreadCount?.total ?? 0;
+
+  const handleMarkAllRead = () => {
+    notifications
+      .filter((n) => !n.isRead)
+      .forEach((n) => markRead.mutate(n.notificationId));
+  };
+
+  return (
+    <div className="flex flex-col p-6 gap-5 bg-gray-50 min-h-screen max-w-3xl">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Bell size={22} className="text-[#0046FF]" />
+          <div>
+            <h1 className="text-[22px] font-bold text-gray-900">알림</h1>
+            {totalUnread > 0 && (
+              <p className="text-[13px] text-gray-400">읽지 않은 알림 {totalUnread}개</p>
+            )}
+          </div>
+        </div>
+        {totalUnread > 0 && (
+          <button
+            onClick={handleMarkAllRead}
+            className="text-[13px] text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+          >
+            모두 읽음
+          </button>
+        )}
+      </div>
+
+      {/* 카테고리 탭 */}
+      <div className="flex gap-2">
+        {TABS.map((tab) => {
+          const isActive = activeTab === tab.id;
+          const count = tab.countKey ? (unreadCount?.[tab.countKey] ?? 0) : 0;
+          return (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex items-center gap-1.5 px-4 py-2 text-[13px] font-semibold rounded-xl cursor-pointer transition-colors ${
+                isActive
+                  ? "bg-[#0046FF] text-white"
+                  : "bg-white text-gray-600 border border-gray-200 hover:bg-gray-50"
+              }`}
+            >
+              {tab.label}
+              {count > 0 && (
+                <span
+                  className={`flex items-center justify-center rounded-full text-[11px] font-bold w-[18px] h-[18px] ${
+                    isActive ? "bg-white text-[#0046FF]" : "bg-red-500 text-white"
+                  }`}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 알림 리스트 */}
+      <div className="flex flex-col gap-3">
+        {filtered.length === 0 ? (
+          <div className="flex items-center justify-center py-16 text-[14px] text-gray-400">
+            알림이 없습니다.
+          </div>
+        ) : (
+          filtered.map((item) => (
+            <NotificationCard
+              key={item.notificationId}
+              item={item}
+              onAccept={(id) => acceptMentor.mutate(id)}
+              onReject={(id) => rejectMentor.mutate(id)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -12,6 +12,7 @@ import DiaryDetailPage from "@/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPag
 import ProfilePage from "@/pages/profile/ProfilePage";
 import UserListPage from "@/pages/user-list/userListPage";
 import AccountPage from "@/pages/account/AccountPage";
+import NotificationPage from "@/pages/notification/NotificationPage";
 
 export const router = createBrowserRouter([
   {
@@ -39,6 +40,7 @@ export const router = createBrowserRouter([
             ],
           },
           { path: "users", element: <UserListPage /> },
+          { path: "notifications", element: <NotificationPage /> },
         ],
       },
     ],


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #45

## 💡 작업 배경
  - 알림 API 타입 및 훅 정의 (notificationApi.ts)
  - 알림 카드 컴포넌트 구현 (NotificationCard) — 멘토신청 / 주문체결 / 팔로우 거래알림 타입별 UI
  - 알림 페이지 구현 (NotificationPage) — 카테고리 탭 필터 + 읽지 않은 알림 수 표시
  - 사이드바 알림 메뉴에 미읽음 뱃지 연결
  - 라우터 /notifications 등록

## 🧩 작업 내용
  - notificationApi.ts: useNotificationsQuery, useUnreadCountQuery, useMarkReadMutation, useAcceptMentorMutation, useRejectMentorMutation 구현
  - 카드 클릭 시 읽음 처리 API 자동 호출
  - 멘토 신청 카드에서 수락/거절 버튼 클릭 시 API 연결
  - 탭 필터: 전체 / 멘토신청 / 주문체결 / 팔로우 (미읽음 카운트 뱃지 포함)
  - 헤더 고정 + 리스트 스크롤 레이아웃

## 📸 스크린샷(선택)
<img width="1887" height="902" alt="image" src="https://github.com/user-attachments/assets/ea7491ee-96d8-4f75-a4d6-b62df419e2fa" />

