### PR TITLE
[Feat] 나의 멘토 페이지 구현

### DIFF
--- a/src/api/mentorApi.ts
+++ b/src/api/mentorApi.ts
@@ -79,7 +79,7 @@ export function useMentorDiariesQuery(userId: number) {
     queryKey: mentorQueryKeys.diaries(userId),
     queryFn: () =>
       fetchClient
-        .get<ApiResponse<MyDiariesItem[]>>(`/api/diaries/user/${userId}`)
+        .get<ApiResponse<MyDiariesItem[]>>(`/api/diaries/users/${userId}`)
         .then((res) => res.data),
     staleTime: 30_000,
     enabled: !!userId,

--- a/src/api/mentorApi.ts
+++ b/src/api/mentorApi.ts
@@ -1,0 +1,99 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchClient } from "@/lib/fetchClient";
+import type { ApiResponse } from "./authApi";
+import type { MyDiariesItem } from "./tradeDiaryApi";
+import type { TradeHistoryItem } from "./tradeApi";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type MentorInfo = {
+  userId: number;
+  nickname: string;
+  imageUrl: string;
+  followerCount: number;
+  followingCount: number;
+  mentoringStatus: string;
+  me: boolean;
+  following: boolean;
+};
+
+export type MentorHoldingItem = {
+  tickerCode: string;
+  stockName: string;
+  stockLogo: string;
+  quantity: number;
+  currentPrice: number;
+  evaluation: number;
+  returnRate: number;
+  returnAmount: number;
+};
+
+// ─── Query Keys ───────────────────────────────────────────────────────────────
+
+export const mentorQueryKeys = {
+  mentor: ["mentor"] as const,
+  holdings: (userId: number) => ["mentor", userId, "holdings"] as const,
+  diaries: (userId: number) => ["mentor", userId, "diaries"] as const,
+  history: (userId: number) => ["mentor", userId, "history"] as const,
+};
+
+// ─── Hooks ────────────────────────────────────────────────────────────────────
+
+export function useMyMentorQuery() {
+  return useQuery({
+    queryKey: mentorQueryKeys.mentor,
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<MentorInfo>>("/api/mentor-requests/my")
+        .then((res) => res.data),
+    staleTime: 30_000,
+  });
+}
+
+export function useUserProfileQuery(userId: number) {
+  return useQuery({
+    queryKey: ["users", userId],
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<MentorInfo>>(`/api/users/${userId}`)
+        .then((res) => res.data),
+    staleTime: 30_000,
+    enabled: !!userId,
+  });
+}
+
+export function useMentorHoldingsQuery(userId: number) {
+  return useQuery({
+    queryKey: mentorQueryKeys.holdings(userId),
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<MentorHoldingItem[]>>(`/api/holdings/${userId}`)
+        .then((res) => res.data),
+    staleTime: 30_000,
+    enabled: !!userId,
+  });
+}
+
+export function useMentorDiariesQuery(userId: number) {
+  return useQuery({
+    queryKey: mentorQueryKeys.diaries(userId),
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<MyDiariesItem[]>>(`/api/diaries/user/${userId}`)
+        .then((res) => res.data),
+    staleTime: 30_000,
+    enabled: !!userId,
+  });
+}
+
+export function useMentorTradeHistoryQuery(userId: number) {
+  return useQuery({
+    queryKey: mentorQueryKeys.history(userId),
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<TradeHistoryItem[]>>(`/api/trades/history/${userId}`)
+        .then((res) => res.data),
+    staleTime: 30_000,
+    enabled: !!userId,
+  });
+}

--- a/src/api/userListApi.ts
+++ b/src/api/userListApi.ts
@@ -1,5 +1,5 @@
 import { fetchClient } from "@/lib/fetchClient";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
 import type { ApiResponse } from "./authApi";
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/components/profile/PortfolioTab.tsx
+++ b/src/components/profile/PortfolioTab.tsx
@@ -10,6 +10,8 @@ type Props = {
   totalReturnAmount: number;
   portfolio: PortfolioItem[];
   holdings: HoldingItem[];
+  compact?: boolean;
+  showAvgPrice?: boolean;
 };
 
 function fmt(n: number) {
@@ -23,6 +25,8 @@ export default function PortfolioTab({
   totalReturnAmount,
   portfolio,
   holdings,
+  compact = true,
+  showAvgPrice = false,
 }: Props) {
   const isPositive = totalReturnRate >= 0;
 
@@ -48,8 +52,8 @@ export default function PortfolioTab({
       </div>
 
       <div className="grid grid-cols-[1fr_2fr] gap-3 flex-1 min-h-0">
-        <PortfolioChart items={portfolio} compact totalEvaluation={totalEvaluation} />
-        <HoldingList items={holdings} showAvgPrice={false} compact />
+        <PortfolioChart items={portfolio} compact={compact} totalEvaluation={totalEvaluation} />
+        <HoldingList items={holdings} showAvgPrice={showAvgPrice} compact={compact} />
       </div>
     </div>
   );

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -69,38 +69,34 @@ export default function MyMentorPage() {
       {/* 멘토 카드 */}
       <div className="bg-white rounded-2xl border border-gray-100 px-6 py-4 shrink-0">
         <div className="flex items-center gap-4">
-          {/* 아바타 + 닉네임 + 배지 */}
-          <div className="flex items-center gap-3 shrink-0">
+          {/* 아바타 + 닉네임 + 통계 */}
+          <div className="flex items-center gap-3 flex-1">
             <Avatar name={mentor.nickname} src={mentor.imageUrl || undefined} size={52} />
-            <div>
+            <div className="flex flex-col gap-1">
               <div className="flex items-center gap-2">
                 <span className="text-[16px] font-bold text-gray-900">{mentor.nickname}</span>
                 <span className="text-[11px] font-semibold text-amber-600 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded-full">멘토</span>
               </div>
-            </div>
-          </div>
-
-          <div className="w-px h-10 bg-gray-100 mx-1 shrink-0" />
-
-          {/* 통계 */}
-          <div className="flex items-center gap-6 flex-1">
-            <div className="flex items-center gap-1.5 text-[13px] text-gray-500">
-              <Users size={13} className="text-gray-400" />
-              <span>팔로워</span>
-              <span className="font-semibold text-gray-800">{mentor.followerCount.toLocaleString()}명</span>
-            </div>
-            <div className="flex items-center gap-1.5 text-[13px] text-gray-500">
-              <TrendingUp size={13} className="text-gray-400" />
-              <span>총 수익률</span>
-              <span className={`font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-                {isPositive ? "+" : ""}{mentor.totalReturnRate.toFixed(1)}%
-              </span>
-            </div>
-            <div className="flex items-center gap-1.5 text-[13px] text-gray-500">
-              <span>총 수익</span>
-              <span className={`font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-                {isPositive ? "+" : ""}{fmtAmount(mentor.totalReturnAmount)}
-              </span>
+              <div className="flex items-center gap-4 text-[13px] text-gray-500">
+                <div className="flex items-center gap-1">
+                  <Users size={12} className="text-gray-400" />
+                  <span>팔로워</span>
+                  <span className="font-semibold text-gray-700 ml-0.5">{mentor.followerCount.toLocaleString()}명</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <TrendingUp size={12} className="text-gray-400" />
+                  <span>총 수익률</span>
+                  <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+                    {isPositive ? "+" : ""}{mentor.totalReturnRate.toFixed(1)}%
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span>총 수익</span>
+                  <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+                    {isPositive ? "+" : ""}{fmtAmount(mentor.totalReturnAmount)}
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
 

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -7,7 +7,7 @@ import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
 import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
 import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
 import PortfolioTab from "@/components/profile/PortfolioTab";
-import { useMyMentorQuery, useUserProfileQuery, useMentorHoldingsQuery, useMentorDiariesQuery, useMentorTradeHistoryQuery } from "@/api/mentorApi";
+import { useUserProfileQuery, useMentorHoldingsQuery, useMentorDiariesQuery, useMentorTradeHistoryQuery } from "@/api/mentorApi";
 import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -32,10 +32,8 @@ export default function MyMentorPage() {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<TabId>("portfolio");
 
-  const { data: mentorRef, isLoading: loadingMentor } = useMyMentorQuery();
-  const mentorId = mentorRef?.userId ?? 0;
-
-  const { data: mentor } = useUserProfileQuery(mentorId);
+  const mentorId = 10;
+  const { data: mentor, isLoading: loadingMentor } = useUserProfileQuery(mentorId);
   const { data: summary } = useAccountSummaryByUserQuery(mentorId);
   const { data: holdingsRaw = [] } = useMentorHoldingsQuery(mentorId);
   const { data: diaries = [] } = useMentorDiariesQuery(mentorId);

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Users, TrendingUp, Loader2 } from "lucide-react";
+import { Users, TrendingUp, Loader2, X } from "lucide-react";
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
@@ -28,9 +28,33 @@ function fmtAmount(n: number) {
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
+function CancelMentorModal({ mentorNickname, onClose, onConfirm }: { mentorNickname: string; onClose: () => void; onConfirm: () => void }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div className="bg-white rounded-2xl w-[360px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <p className="text-[15px] font-bold text-gray-900">멘토 취소</p>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors">
+            <X size={18} />
+          </button>
+        </div>
+        <div className="px-6 py-6">
+          <p className="text-[14px] text-gray-700 font-medium mb-1"><span className="font-bold text-[#0046FF]">{mentorNickname}</span> 멘토를 취소하시겠어요?</p>
+          <p className="text-[13px] text-gray-400">멘토 취소 후에도 다시 신청할 수 있어요.</p>
+        </div>
+        <div className="flex gap-2 px-6 pb-6">
+          <Button variant="invalid" className="flex-1 py-2.5" onClick={onClose}>취소</Button>
+          <Button variant="danger" className="flex-1 py-2.5" onClick={onConfirm}>멘토 취소</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function MyMentorPage() {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<TabId>("portfolio");
+  const [showCancelModal, setShowCancelModal] = useState(false);
 
   const mentorId = 10;
   const { data: mentor, isLoading: loadingMentor } = useUserProfileQuery(mentorId);
@@ -74,6 +98,16 @@ export default function MyMentorPage() {
 
   return (
     <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50">
+      {showCancelModal && (
+        <CancelMentorModal
+          mentorNickname={mentor.nickname}
+          onClose={() => setShowCancelModal(false)}
+          onConfirm={() => {
+            // TODO: 멘토 취소 API 연동
+            setShowCancelModal(false);
+          }}
+        />
+      )}
       {/* 헤더 */}
       <div>
         <h1 className="text-[22px] font-bold text-gray-900">나의 멘토</h1>
@@ -118,7 +152,7 @@ export default function MyMentorPage() {
             <Button variant="basic" className="px-4 py-2 text-[13px]" onClick={() => navigate(`/users/${mentor.userId}`)}>
               프로필 보기
             </Button>
-            <Button variant="danger" className="px-4 py-2 text-[13px] flex items-center gap-1.5">
+            <Button variant="danger" className="px-4 py-2 text-[13px] flex items-center gap-1.5" onClick={() => setShowCancelModal(true)}>
               <Users size={13} />
               멘토 취소
             </Button>

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -1,39 +1,14 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Users, TrendingUp } from "lucide-react";
+import { Users, TrendingUp, Loader2 } from "lucide-react";
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
 import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
 import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
 import PortfolioTab from "@/components/profile/PortfolioTab";
-
-// ─── Mock Data ────────────────────────────────────────────────────────────────
-
-const MOCK_MENTOR = {
-  userId: 10,
-  nickname: "주식마스터",
-  imageUrl: "",
-  followerCount: 542,
-  totalReturnRate: 48.3,
-  totalReturnAmount: 18500000,
-};
-
-const MOCK_PORTFOLIO = [
-  { tickerCode: "005930", name: "삼성전자", ratio: 30 },
-  { tickerCode: "000660", name: "SK하이닉스", ratio: 20 },
-  { tickerCode: "035420", name: "NAVER", ratio: 18 },
-  { tickerCode: "005380", name: "현대차", ratio: 17 },
-  { tickerCode: "105560", name: "KB금융", ratio: 15 },
-];
-
-const MOCK_HOLDINGS = [
-  { tickerCode: "005930", stockName: "삼성전자", stockLogo: "", quantity: 15, averageBuyPrice: 0, currentPrice: 73400, evaluationAmount: 1101000, profitRate: 7.62, profitAmount: 78000 },
-  { tickerCode: "000660", stockName: "SK하이닉스", stockLogo: "", quantity: 5, averageBuyPrice: 0, currentPrice: 192500, evaluationAmount: 962500, profitRate: 10.63, profitAmount: 92500 },
-  { tickerCode: "035420", stockName: "NAVER", stockLogo: "", quantity: 12, averageBuyPrice: 0, currentPrice: 178000, evaluationAmount: 2136000, profitRate: 7.87, profitAmount: 156800 },
-  { tickerCode: "005380", stockName: "현대차", stockLogo: "", quantity: 8, averageBuyPrice: 0, currentPrice: 241500, evaluationAmount: 1932000, profitRate: 7.33, profitAmount: 132000 },
-  { tickerCode: "105560", stockName: "KB금융", stockLogo: "", quantity: 35, averageBuyPrice: 0, currentPrice: 87200, evaluationAmount: 3052000, profitRate: 9.04, profitAmount: 253000 },
-];
+import { useMyMentorQuery, useUserProfileQuery, useMentorHoldingsQuery, useMentorDiariesQuery, useMentorTradeHistoryQuery } from "@/api/mentorApi";
+import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -56,8 +31,48 @@ function fmtAmount(n: number) {
 export default function MyMentorPage() {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<TabId>("portfolio");
-  const mentor = MOCK_MENTOR;
-  const isPositive = mentor.totalReturnRate >= 0;
+
+  const { data: mentorRef, isLoading: loadingMentor } = useMyMentorQuery();
+  const mentorId = mentorRef?.userId ?? 0;
+
+  const { data: mentor } = useUserProfileQuery(mentorId);
+  const { data: summary } = useAccountSummaryByUserQuery(mentorId);
+  const { data: holdingsRaw = [] } = useMentorHoldingsQuery(mentorId);
+  const { data: diaries = [] } = useMentorDiariesQuery(mentorId);
+  const { data: tradeHistories = [] } = useMentorTradeHistoryQuery(mentorId);
+
+  const holdings = holdingsRaw.map((h) => ({
+    tickerCode: h.tickerCode,
+    stockName: h.stockName,
+    stockLogo: h.stockLogo,
+    quantity: h.quantity,
+    averageBuyPrice: 0,
+    currentPrice: h.currentPrice,
+    evaluationAmount: h.evaluation,
+    profitRate: h.returnRate,
+    profitAmount: h.returnAmount,
+  }));
+
+  if (loadingMentor) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-screen">
+        <Loader2 size={32} className="animate-spin text-[#0046FF]" />
+      </div>
+    );
+  }
+
+  if (!mentor) {
+    return (
+      <div className="flex flex-col h-screen p-6 gap-5 bg-gray-50">
+        <h1 className="text-[22px] font-bold text-gray-900">나의 멘토</h1>
+        <div className="flex-1 flex items-center justify-center text-[14px] text-gray-400">
+          아직 멘토가 없습니다.
+        </div>
+      </div>
+    );
+  }
+
+  const isPositive = (summary?.totalReturnRate ?? 0) >= 0;
 
   return (
     <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50">
@@ -87,13 +102,13 @@ export default function MyMentorPage() {
                   <TrendingUp size={12} className="text-gray-400" />
                   <span>총 수익률</span>
                   <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-                    {isPositive ? "+" : ""}{mentor.totalReturnRate.toFixed(1)}%
+                    {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(1)}%
                   </span>
                 </div>
                 <div className="flex items-center gap-1">
                   <span>총 수익</span>
                   <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-                    {isPositive ? "+" : ""}{fmtAmount(mentor.totalReturnAmount)}
+                    {isPositive ? "+" : ""}{fmtAmount(summary?.totalReturnAmount ?? 0)}
                   </span>
                 </div>
               </div>
@@ -121,15 +136,15 @@ export default function MyMentorPage() {
           onChange={(id) => setActiveTab(id as TabId)}
         />
         <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
-          {activeTab === "diary" && <TradeDiaryTab items={[]} />}
-          {activeTab === "history" && <TradeHistoryTab items={[]} />}
+          {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
+          {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
           {activeTab === "portfolio" && (
             <PortfolioTab
-              totalEvaluation={9183500}
-              totalReturnRate={12.5}
-              totalReturnAmount={1250000}
-              portfolio={MOCK_PORTFOLIO}
-              holdings={MOCK_HOLDINGS}
+              totalEvaluation={summary?.totalEvaluation ?? 0}
+              totalReturnRate={summary?.totalReturnRate ?? 0}
+              totalReturnAmount={summary?.totalReturnAmount ?? 0}
+              portfolio={summary?.holdingsRatio ?? []}
+              holdings={holdings}
               compact={false}
               showAvgPrice={false}
             />

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Users, TrendingUp } from "lucide-react";
+import Avatar from "@/components/ui/Avatar";
+import Button from "@/components/ui/Button";
+import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
+import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
+import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
+import PortfolioTab from "@/components/profile/PortfolioTab";
+
+// ─── Mock Data ────────────────────────────────────────────────────────────────
+
+const MOCK_MENTOR = {
+  userId: 10,
+  nickname: "주식마스터",
+  imageUrl: "",
+  followerCount: 542,
+  totalReturnRate: 48.3,
+  totalReturnAmount: 18500000,
+};
+
+const MOCK_PORTFOLIO = [
+  { tickerCode: "005930", name: "삼성전자", ratio: 30 },
+  { tickerCode: "000660", name: "SK하이닉스", ratio: 20 },
+  { tickerCode: "035420", name: "NAVER", ratio: 18 },
+  { tickerCode: "005380", name: "현대차", ratio: 17 },
+  { tickerCode: "105560", name: "KB금융", ratio: 15 },
+];
+
+const MOCK_HOLDINGS = [
+  { tickerCode: "005930", stockName: "삼성전자", stockLogo: "", quantity: 15, averageBuyPrice: 0, currentPrice: 73400, evaluationAmount: 1101000, profitRate: 7.62, profitAmount: 78000 },
+  { tickerCode: "000660", stockName: "SK하이닉스", stockLogo: "", quantity: 5, averageBuyPrice: 0, currentPrice: 192500, evaluationAmount: 962500, profitRate: 10.63, profitAmount: 92500 },
+  { tickerCode: "035420", stockName: "NAVER", stockLogo: "", quantity: 12, averageBuyPrice: 0, currentPrice: 178000, evaluationAmount: 2136000, profitRate: 7.87, profitAmount: 156800 },
+  { tickerCode: "005380", stockName: "현대차", stockLogo: "", quantity: 8, averageBuyPrice: 0, currentPrice: 241500, evaluationAmount: 1932000, profitRate: 7.33, profitAmount: 132000 },
+  { tickerCode: "105560", stockName: "KB금융", stockLogo: "", quantity: 35, averageBuyPrice: 0, currentPrice: 87200, evaluationAmount: 3052000, profitRate: 9.04, profitAmount: 253000 },
+];
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TABS = [
+  { id: "diary", label: "매매일지" },
+  { id: "history", label: "매매내역" },
+  { id: "portfolio", label: "포트폴리오" },
+] as const;
+
+type TabId = (typeof TABS)[number]["id"];
+
+function fmtAmount(n: number) {
+  if (Math.abs(n) >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}억`;
+  if (Math.abs(n) >= 10_000) return `${(n / 10_000).toFixed(0)}만원`;
+  return `${n.toLocaleString()}원`;
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function MyMentorPage() {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<TabId>("portfolio");
+  const mentor = MOCK_MENTOR;
+  const isPositive = mentor.totalReturnRate >= 0;
+
+  return (
+    <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50">
+      {/* 헤더 */}
+      <div>
+        <h1 className="text-[22px] font-bold text-gray-900">나의 멘토</h1>
+      </div>
+
+      {/* 멘토 카드 */}
+      <div className="bg-white rounded-2xl border border-gray-100 px-6 py-4 shrink-0">
+        <div className="flex items-center gap-4">
+          {/* 아바타 + 닉네임 + 배지 */}
+          <div className="flex items-center gap-3 shrink-0">
+            <Avatar name={mentor.nickname} src={mentor.imageUrl || undefined} size={52} />
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="text-[16px] font-bold text-gray-900">{mentor.nickname}</span>
+                <span className="text-[11px] font-semibold text-amber-600 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded-full">멘토</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="w-px h-10 bg-gray-100 mx-1 shrink-0" />
+
+          {/* 통계 */}
+          <div className="flex items-center gap-6 flex-1">
+            <div className="flex items-center gap-1.5 text-[13px] text-gray-500">
+              <Users size={13} className="text-gray-400" />
+              <span>팔로워</span>
+              <span className="font-semibold text-gray-800">{mentor.followerCount.toLocaleString()}명</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-[13px] text-gray-500">
+              <TrendingUp size={13} className="text-gray-400" />
+              <span>총 수익률</span>
+              <span className={`font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+                {isPositive ? "+" : ""}{mentor.totalReturnRate.toFixed(1)}%
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5 text-[13px] text-gray-500">
+              <span>총 수익</span>
+              <span className={`font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+                {isPositive ? "+" : ""}{fmtAmount(mentor.totalReturnAmount)}
+              </span>
+            </div>
+          </div>
+
+          {/* 버튼 */}
+          <div className="flex items-center gap-2 shrink-0">
+            <Button variant="basic" className="px-4 py-2 text-[13px]" onClick={() => navigate(`/users/${mentor.userId}`)}>
+              프로필 보기
+            </Button>
+            <Button variant="danger" className="px-4 py-2 text-[13px] flex items-center gap-1.5">
+              <Users size={13} />
+              멘토 취소
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* 탭 + 콘텐츠 */}
+      <div className="flex-1 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
+        <UnderlineTabBar
+          tabs={[...TABS]}
+          activeId={activeTab}
+          onChange={(id) => setActiveTab(id as TabId)}
+        />
+        <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
+          {activeTab === "diary" && <TradeDiaryTab items={[]} />}
+          {activeTab === "history" && <TradeHistoryTab items={[]} />}
+          {activeTab === "portfolio" && (
+            <PortfolioTab
+              totalEvaluation={9183500}
+              totalReturnRate={12.5}
+              totalReturnAmount={1250000}
+              portfolio={MOCK_PORTFOLIO}
+              holdings={MOCK_HOLDINGS}
+              compact={false}
+              showAvgPrice={false}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -12,6 +12,7 @@ import DiaryDetailPage from "@/pages/trade-diaries/[tradeDiaryId]/DiaryDetailPag
 import ProfilePage from "@/pages/profile/ProfilePage";
 import UserListPage from "@/pages/user-list/userListPage";
 import AccountPage from "@/pages/account/AccountPage";
+import MyMentorPage from "@/pages/mentor/MyMentorPage";
 
 export const router = createBrowserRouter([
   {
@@ -39,6 +40,7 @@ export const router = createBrowserRouter([
             ],
           },
           { path: "users", element: <UserListPage /> },
+          { path: "mentor", element: <MyMentorPage /> },
         ],
       },
     ],

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -40,6 +40,7 @@ export const router = createBrowserRouter([
             ],
           },
           { path: "users", element: <UserListPage /> },
+          { path: "users/:userId", element: <div /> },
           { path: "mentor", element: <MyMentorPage /> },
         ],
       },


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #51 

## 💡 작업 배경
내 멘토 화면이 필요함

## 🧩 작업 내용
  - 나의 멘토 페이지 구현 (/mentor)                                             
    - 멘토 카드: 프로필 이미지, 닉네임, 멘토 배지, 팔로워/총 수익률/총 수익 표시
    - 탭: 매매일지, 매매내역, 포트폴리오 (평균단가 미표시)                      
  - GET /api/users/{userId}, /api/account/summary/{userId} 연동                 
  - GET /api/holdings/{userId}, /api/diaries/users/{userId},                    
  /api/trades/history/{userId} 연동                                             
  - 멘토 취소 버튼 클릭 시 확인 모달 표시                                       
  - /users/:userId 라우터 추가 (유저 프로필 페이지 연결 예정)                   
  - useInfiniteQuery import 누락 버그 수정      

## 📸 스크린샷(선택)
<img width="1328" height="889" alt="Screenshot 2026-03-26 at 11 41 25 PM" src="https://github.com/user-attachments/assets/d1f3aadf-5827-462e-8aab-a7f643a728d8" />


## 📝 기타
추후 타인 프로필 완성 후 라우터 설정 예정
내 멘토, 멘티 api 추후 만들어질 예정이라 예시로 10번 사용자로 하드 코딩 해놓았습니다.