### PR TITLE
[Feat] 멘티 화면 구현

### DIFF
--- a/src/api/mentorApi.ts
+++ b/src/api/mentorApi.ts
@@ -17,6 +17,15 @@ export type MentorInfo = {
   following: boolean;
 };
 
+export type MenteeItem = {
+  userId: number;
+  nickname: string;
+  imageUrl: string;
+  followerCount: number;
+  totalReturnRate: number;
+  totalReturnAmount: number;
+};
+
 export type MentorHoldingItem = {
   tickerCode: string;
   stockName: string;
@@ -32,6 +41,7 @@ export type MentorHoldingItem = {
 
 export const mentorQueryKeys = {
   mentor: ["mentor"] as const,
+  mentees: ["mentees"] as const,
   holdings: (userId: number) => ["mentor", userId, "holdings"] as const,
   diaries: (userId: number) => ["mentor", userId, "diaries"] as const,
   history: (userId: number) => ["mentor", userId, "history"] as const,
@@ -83,6 +93,17 @@ export function useMentorDiariesQuery(userId: number) {
         .then((res) => res.data),
     staleTime: 30_000,
     enabled: !!userId,
+  });
+}
+
+export function useMyMenteesQuery() {
+  return useQuery({
+    queryKey: mentorQueryKeys.mentees,
+    queryFn: () =>
+      fetchClient
+        .get<ApiResponse<MenteeItem[]>>("/api/mentor-requests/mentees")
+        .then((res) => res.data),
+    staleTime: 30_000,
   });
 }
 

--- a/src/components/profile/EditProfileModal.tsx
+++ b/src/components/profile/EditProfileModal.tsx
@@ -4,6 +4,7 @@ import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
 import { fetchClient } from "@/lib/fetchClient";
 import { useAuthStore } from "@/store/authStore";
+import { useQueryClient } from "@tanstack/react-query";
 import type { ApiResponse } from "@/api/authApi";
 
 type Props = {
@@ -14,6 +15,7 @@ type Props = {
 };
 
 export default function EditProfileModal({ nickname, profileImageUrl, onClose, onSave }: Props) {
+  const queryClient = useQueryClient();
   const [nicknameValue, setNicknameValue] = useState(nickname);
   const [nicknameChecked, setNicknameChecked] = useState(false);
   const [nicknameMsg, setNicknameMsg] = useState<{ text: string; ok: boolean } | null>(null);
@@ -61,19 +63,22 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
       const token = useAuthStore.getState().accessToken;
       const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
       const formData = new FormData();
-      formData.append("nickname", nicknameValue);
-      if (imageFile) formData.append("profileImage", imageFile);
+      if (nicknameValue !== nickname) formData.append("nickname", nicknameValue);
+      if (imageFile) formData.append("image", imageFile);
 
-      await fetch(`${BASE_URL}/api/users/profile`, {
+      const res = await fetch(`${BASE_URL}/api/users/profile`, {
         method: "PATCH",
         headers: token ? { Authorization: `Bearer ${token}` } : {},
         credentials: "include",
         body: formData,
       });
 
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await queryClient.invalidateQueries({ queryKey: ["users", "me"] });
       onSave(nicknameValue);
       onClose();
-    } catch {
+    } catch (e) {
+      console.error("프로필 저장 실패:", e);
       setNicknameMsg({ text: "저장에 실패했어요. 다시 시도해주세요.", ok: false });
     } finally {
       setSaving(false);

--- a/src/components/profile/MenteeTradeDiaryTab.tsx
+++ b/src/components/profile/MenteeTradeDiaryTab.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import Badge from "@/components/ui/Badge";
+import Avatar from "@/components/ui/Avatar";
+import { useUser } from "@/store/authStore";
+import { useMyProfileQuery } from "@/api/userListApi";
+import type { MyDiariesItem } from "@/api/tradeDiaryApi";
+
+type Props = {
+  items: MyDiariesItem[];
+  onFeedback?: (diaryId: number, content: string) => Promise<void>;
+};
+
+function FeedbackInput({ diaryId, onSubmit }: { diaryId: number; onSubmit: (diaryId: number, content: string) => Promise<void> }) {
+  const user = useUser();
+  const { data: myProfile } = useMyProfileQuery();
+  const [value, setValue] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!value.trim() || loading) return;
+    setLoading(true);
+    try {
+      await onSubmit(diaryId, value.trim());
+      setValue("");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5 mt-1">
+      <p className="text-[12px] font-semibold text-gray-500">멘토 피드백</p>
+      <div className="flex items-center gap-2">
+        <Avatar name={user?.nickname ?? ""} src={myProfile?.imageUrl} size={28} />
+        <div className="flex flex-1 items-center gap-2 border border-gray-200 rounded-xl px-3 py-2 focus-within:border-[#0046FF] transition-colors">
+          <input
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+            placeholder="피드백을 남겨주세요..."
+            className="flex-1 text-[13px] outline-none bg-transparent text-gray-700 placeholder:text-gray-400"
+          />
+          <button
+            onClick={handleSubmit}
+            disabled={!value.trim() || loading}
+            className="text-[12px] font-semibold text-white bg-[#0046FF] px-3 py-1 rounded-lg disabled:opacity-40 transition-opacity shrink-0"
+          >
+            {loading ? "등록 중" : "등록"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function MenteeTradeDiaryTab({ items, onFeedback }: Props) {
+  if (items.length === 0) {
+    return (
+      <div className="text-center py-12 text-[14px] text-gray-400">
+        매매일지가 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      {items.map((item) => {
+        const isBuy = item.tradeType === "BUY";
+        const isPositive = (item.profit ?? 0) >= 0;
+
+        return (
+          <div
+            key={item.diaryId}
+            className="flex flex-col gap-2 px-6 py-5 border-b border-gray-100 last:border-b-0"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Badge name={isBuy ? "매수" : "매도"} color={isBuy ? "#FF4444" : "#0046FF"} />
+                <span className="text-[15px] font-bold text-gray-900">{item.stockName}</span>
+                <span className="text-[13px] text-gray-400">{item.quantity}주</span>
+                <span className="text-gray-300">·</span>
+                <span className="text-[13px] text-gray-400">{item.filledPrice?.toLocaleString() ?? "-"}원</span>
+                <span className="text-gray-300">·</span>
+                <span className="text-[13px] text-gray-400">{item.createdAt.slice(0, 10).replace(/-/g, ".")}</span>
+              </div>
+              {item.profit != null && item.profit !== 0 && (
+                <span className={`text-[13px] font-semibold ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
+                  {isPositive ? "+" : ""}{item.profit?.toLocaleString()}원
+                </span>
+              )}
+            </div>
+            <p className="text-[14px] text-gray-700 leading-relaxed">{item.content}</p>
+            {onFeedback && (
+              <FeedbackInput diaryId={item.diaryId} onSubmit={onFeedback} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/profile/MentorTradeDiaryTab.tsx
+++ b/src/components/profile/MentorTradeDiaryTab.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import Badge from "@/components/ui/Badge";
+import Avatar from "@/components/ui/Avatar";
+import { useUser } from "@/store/authStore";
+import { useMyProfileQuery } from "@/api/userListApi";
+import type { MyDiariesItem } from "@/api/tradeDiaryApi";
+
+type Props = {
+  items: MyDiariesItem[];
+  onAskQuestion?: (diaryId: number, content: string) => Promise<void>;
+};
+
+function QuestionInput({ diaryId, onSubmit }: { diaryId: number; onSubmit: (diaryId: number, content: string) => Promise<void> }) {
+  const user = useUser();
+  const { data: myProfile } = useMyProfileQuery();
+  const [value, setValue] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!value.trim() || loading) return;
+    setLoading(true);
+    try {
+      await onSubmit(diaryId, value.trim());
+      setValue("");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2 mt-1">
+      <Avatar name={user?.nickname ?? ""} src={myProfile?.imageUrl} size={28} />
+      <div className="flex flex-1 items-center gap-2 border border-gray-200 rounded-xl px-3 py-2 focus-within:border-[#0046FF] transition-colors">
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+          placeholder="멘토에게 질문하기..."
+          className="flex-1 text-[13px] outline-none bg-transparent text-gray-700 placeholder:text-gray-400"
+        />
+        <button
+          onClick={handleSubmit}
+          disabled={!value.trim() || loading}
+          className="text-[12px] font-semibold text-white bg-[#0046FF] px-3 py-1 rounded-lg disabled:opacity-40 transition-opacity shrink-0"
+        >
+          {loading ? "등록 중" : "등록"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function MentorTradeDiaryTab({ items, onAskQuestion }: Props) {
+  if (items.length === 0) {
+    return (
+      <div className="text-center py-12 text-[14px] text-gray-400">
+        매매일지가 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      {items.map((item) => {
+        const isBuy = item.tradeType === "BUY";
+        const isPositive = (item.profit ?? 0) >= 0;
+
+        return (
+          <div
+            key={item.diaryId}
+            className="flex flex-col gap-2 px-6 py-5 border-b border-gray-100 last:border-b-0"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Badge name={isBuy ? "매수" : "매도"} color={isBuy ? "#FF4444" : "#0046FF"} />
+                <span className="text-[15px] font-bold text-gray-900">{item.stockName}</span>
+                <span className="text-[13px] text-gray-400">{item.quantity}주</span>
+                <span className="text-gray-300">·</span>
+                <span className="text-[13px] text-gray-400">{item.filledPrice?.toLocaleString() ?? "-"}원</span>
+                <span className="text-gray-300">·</span>
+                <span className="text-[13px] text-gray-400">{item.createdAt.slice(0, 10).replace(/-/g, ".")}</span>
+              </div>
+              {item.profit != null && item.profit !== 0 && (
+                <span className={`text-[13px] font-semibold ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
+                  {isPositive ? "+" : ""}{item.profit?.toLocaleString()}원
+                </span>
+              )}
+            </div>
+            <p className="text-[14px] text-gray-700 leading-relaxed">{item.content}</p>
+            {onAskQuestion && (
+              <QuestionInput diaryId={item.diaryId} onSubmit={onAskQuestion} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/mentee/MyMenteePage.tsx
+++ b/src/pages/mentee/MyMenteePage.tsx
@@ -1,0 +1,222 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Users, TrendingUp, Loader2 } from "lucide-react";
+import Avatar from "@/components/ui/Avatar";
+import Button from "@/components/ui/Button";
+import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
+import MenteeTradeDiaryTab from "@/components/profile/MenteeTradeDiaryTab";
+import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
+import PortfolioTab from "@/components/profile/PortfolioTab";
+import {
+  useUserProfileQuery,
+  useMentorHoldingsQuery,
+  useMentorDiariesQuery,
+  useMentorTradeHistoryQuery,
+} from "@/api/mentorApi";
+import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TABS = [
+  { id: "diary", label: "매매일지" },
+  { id: "history", label: "매매내역" },
+  { id: "portfolio", label: "포트폴리오" },
+] as const;
+
+type TabId = (typeof TABS)[number]["id"];
+
+function fmtAmount(n: number) {
+  if (Math.abs(n) >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}억`;
+  if (Math.abs(n) >= 10_000) return `${(n / 10_000).toFixed(0)}만원`;
+  return `${n.toLocaleString()}원`;
+}
+
+// ─── Mentee Detail Panel ──────────────────────────────────────────────────────
+
+function MenteeDetail({ menteeId }: { menteeId: number }) {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<TabId>("portfolio");
+
+  const { data: mentee, isLoading } = useUserProfileQuery(menteeId);
+  const { data: summary } = useAccountSummaryByUserQuery(menteeId);
+  const { data: holdingsRaw = [] } = useMentorHoldingsQuery(menteeId);
+  const { data: diaries = [] } = useMentorDiariesQuery(menteeId);
+  const { data: tradeHistories = [] } = useMentorTradeHistoryQuery(menteeId);
+
+  const holdings = holdingsRaw.map((h) => ({
+    tickerCode: h.tickerCode,
+    stockName: h.stockName,
+    stockLogo: h.stockLogo,
+    quantity: h.quantity,
+    averageBuyPrice: 0,
+    currentPrice: h.currentPrice,
+    evaluationAmount: h.evaluation,
+    profitRate: h.returnRate,
+    profitAmount: h.returnAmount,
+  }));
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <Loader2 size={28} className="animate-spin text-[#0046FF]" />
+      </div>
+    );
+  }
+
+  if (!mentee) return null;
+
+  const isPositive = (summary?.totalReturnRate ?? 0) >= 0;
+
+  return (
+    <div className="flex-1 flex flex-col gap-4 min-h-0">
+      {/* 멘티 카드 */}
+      <div className="bg-white rounded-2xl border border-gray-100 px-6 py-4 shrink-0">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-3 flex-1">
+            <Avatar name={mentee.nickname} src={mentee.imageUrl || undefined} size={52} />
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <span className="text-[16px] font-bold text-gray-900">{mentee.nickname}</span>
+                <span className="text-[11px] font-semibold text-blue-600 bg-blue-50 border border-blue-200 px-2 py-0.5 rounded-full">멘티</span>
+              </div>
+              <div className="flex items-center gap-4 text-[13px] text-gray-500">
+                <div className="flex items-center gap-1">
+                  <Users size={12} className="text-gray-400" />
+                  <span>팔로워</span>
+                  <span className="font-semibold text-gray-700 ml-0.5">{mentee.followerCount.toLocaleString()}명</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <TrendingUp size={12} className="text-gray-400" />
+                  <span>총 수익률</span>
+                  <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+                    {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(1)}%
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span>총 수익</span>
+                  <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+                    {isPositive ? "+" : ""}{fmtAmount(summary?.totalReturnAmount ?? 0)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <Button
+            variant="basic"
+            className="px-4 py-2 text-[13px] shrink-0"
+            onClick={() => navigate(`/users/${mentee.userId}`)}
+          >
+            프로필 보기
+          </Button>
+        </div>
+      </div>
+
+      {/* 탭 + 콘텐츠 */}
+      <div className="flex-1 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
+        <UnderlineTabBar
+          tabs={[...TABS]}
+          activeId={activeTab}
+          onChange={(id) => setActiveTab(id as TabId)}
+        />
+        <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
+          {activeTab === "diary" && (
+            <MenteeTradeDiaryTab
+              items={diaries}
+              onFeedback={async (diaryId, content) => {
+                // TODO: 피드백 API 연동
+                console.log("피드백 등록:", diaryId, content);
+              }}
+            />
+          )}
+          {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
+          {activeTab === "portfolio" && (
+            <PortfolioTab
+              totalEvaluation={summary?.totalEvaluation ?? 0}
+              totalReturnRate={summary?.totalReturnRate ?? 0}
+              totalReturnAmount={summary?.totalReturnAmount ?? 0}
+              portfolio={summary?.holdingsRatio ?? []}
+              holdings={holdings}
+              compact={false}
+              showAvgPrice={false}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Mock Data ────────────────────────────────────────────────────────────────
+
+const MOCK_MENTEE_IDS = [1, 5, 6];
+
+// ─── Mentee List Item ─────────────────────────────────────────────────────────
+
+function MenteeListItem({
+  userId,
+  selected,
+  onClick,
+}: {
+  userId: number;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const { data: profile } = useUserProfileQuery(userId);
+  const { data: summary } = useAccountSummaryByUserQuery(userId);
+  const isPositive = (summary?.totalReturnRate ?? 0) >= 0;
+
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl transition-colors text-left ${
+        selected ? "bg-[#0046FF]/8" : "hover:bg-gray-50"
+      }`}
+    >
+      <Avatar name={profile?.nickname ?? ""} src={profile?.imageUrl || undefined} size={36} />
+      <div className="flex-1 min-w-0">
+        <p className="text-[13px] font-semibold text-gray-900 truncate">{profile?.nickname ?? "..."}</p>
+        <p className={`text-[12px] font-semibold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+          {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(1)}%
+        </p>
+      </div>
+    </button>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function MyMenteePage() {
+  const [selectedId, setSelectedId] = useState<number>(MOCK_MENTEE_IDS[0]);
+
+  return (
+    <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50">
+      {/* 헤더 */}
+      <div className="flex items-baseline gap-2 shrink-0">
+        <h1 className="text-[22px] font-bold text-gray-900">나의 멘티</h1>
+        <span className="text-[13px] text-gray-400">총 {MOCK_MENTEE_IDS.length}명의 멘티</span>
+      </div>
+
+      <div className="flex gap-4 flex-1 min-h-0">
+        {/* 멘티 목록 (좌측) */}
+        <div className="w-[180px] shrink-0 bg-white rounded-2xl border border-gray-100 flex flex-col overflow-hidden">
+          <div className="px-4 py-3 border-b border-gray-100 shrink-0">
+            <p className="text-[12px] font-semibold text-gray-400">멘티 목록</p>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2">
+            {MOCK_MENTEE_IDS.map((id) => (
+              <MenteeListItem
+                key={id}
+                userId={id}
+                selected={id === selectedId}
+                onClick={() => setSelectedId(id)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* 멘티 상세 (우측) */}
+        <MenteeDetail key={selectedId} menteeId={selectedId} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -4,7 +4,7 @@ import { Users, TrendingUp, Loader2, X } from "lucide-react";
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
-import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
+import MentorTradeDiaryTab from "@/components/profile/MentorTradeDiaryTab";
 import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
 import PortfolioTab from "@/components/profile/PortfolioTab";
 import { useUserProfileQuery, useMentorHoldingsQuery, useMentorDiariesQuery, useMentorTradeHistoryQuery } from "@/api/mentorApi";
@@ -168,7 +168,15 @@ export default function MyMentorPage() {
           onChange={(id) => setActiveTab(id as TabId)}
         />
         <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
-          {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
+          {activeTab === "diary" && (
+            <MentorTradeDiaryTab
+              items={diaries}
+              onAskQuestion={async (diaryId, content) => {
+                // TODO: 질문 API 연동
+                console.log("질문 등록:", diaryId, content);
+              }}
+            />
+          )}
           {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
           {activeTab === "portfolio" && (
             <PortfolioTab

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -14,6 +14,7 @@ import UserListPage from "@/pages/user-list/userListPage";
 import AccountPage from "@/pages/account/AccountPage";
 import NotificationPage from "@/pages/notification/NotificationPage";
 import MyMentorPage from "@/pages/mentor/MyMentorPage";
+import MyMenteePage from "@/pages/mentee/MyMenteePage";
 
 export const router = createBrowserRouter([
   {
@@ -44,6 +45,7 @@ export const router = createBrowserRouter([
           { path: "notifications", element: <NotificationPage /> },
           { path: "users/:userId", element: <div /> },
           { path: "mentor", element: <MyMentorPage /> },
+          { path: "mentee", element: <MyMenteePage /> },
         ],
       },
     ],


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #58

## 💡 작업 배경
멘티 화면 구현이 필요

## 🧩 작업 내용
- 멘티 화면 구현
- 프로필 편집 시 닉네임 변경없이 사진만 변경시 발생하는 오류 해결
- 멘티 멘토 매매일지에는 댓글 가능하도록 prop 설정

## 📸 스크린샷(선택)
<img width="1338" height="922" alt="Screenshot 2026-03-27 at 1 21 02 AM" src="https://github.com/user-attachments/assets/ae5837b7-d24d-4c59-8115-eb81e0cc9fe2" />


## 📝 기타