### PR TITLE
[Feat] 타인 프로필 구현

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -288,7 +288,7 @@ function TopInvestors({ data, loading }: { data: UserItem[]; loading: boolean })
       ) : (
         <ul className="divide-y divide-gray-50">
           {top5.map((investor, i) => (
-            <li key={investor.userId} className="flex items-center gap-3 px-5 py-3 hover:bg-gray-50/50 transition-colors">
+            <li key={investor.userId} onClick={() => navigate(investor.me ? "/profile" : `/users/${investor.userId}`)} className="flex items-center gap-3 px-5 py-3 hover:bg-gray-50/50 transition-colors cursor-pointer">
               <span className={`w-5 text-[13px] font-bold ${i < 3 ? "text-[#0046FF]" : "text-gray-400"}`}>
                 {i + 1}
               </span>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -208,7 +208,7 @@ function HoldingsTable({ data, loading }: { data: HoldingItem[]; loading: boolea
             {top5.map((stock) => {
               const isPositive = stock.returnRate >= 0;
               return (
-                <tr key={stock.tickerCode} className="hover:bg-gray-50/50 transition-colors">
+                <tr key={stock.tickerCode} onClick={() => navigate(`/invest/${stock.tickerCode}`)} className="hover:bg-gray-50/50 transition-colors cursor-pointer">
                   <td className="px-5 py-3">
                     <div className="flex items-center gap-2.5">
                       <Avatar name={stock.stockName} src={stock.stockLogo || undefined} size={28} color={getAvatarColor(stock.stockName)} />

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Search } from "lucide-react";
 import { useQueries } from "@tanstack/react-query";
 import Avatar from "@/components/ui/Avatar";
@@ -50,9 +51,10 @@ const PODIUM_CONFIG = {
 } as const;
 
 function PodiumSlot({ user, rank }: { user: UserItem; rank: 1 | 2 | 3 }) {
+  const navigate = useNavigate();
   const cfg = PODIUM_CONFIG[rank];
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center cursor-pointer" onClick={() => navigate(user.me ? "/profile" : `/users/${user.userId}`)}>
       {rank === 1 && <span className="text-xl mb-1">👑</span>}
       <Avatar
         name={user.nickname}
@@ -213,6 +215,7 @@ function UserRow({
   onMentoringRequest: (user: UserItem) => void;
   onMentoringCancel: (user: UserItem) => void;
 }) {
+  const navigate = useNavigate();
   return (
     <tr className={`border-b border-gray-50 hover:bg-gray-50/50 transition-colors ${user.me ? "bg-blue-50/40" : ""}`}>
       {/* 순위 */}
@@ -224,7 +227,7 @@ function UserRow({
 
       {/* 투자자 */}
       <td className="px-2 py-3.5">
-        <div className="flex items-center gap-2.5">
+        <div className="flex items-center gap-2.5 cursor-pointer hover:opacity-70 transition-opacity w-fit" onClick={() => navigate(user.me ? "/profile" : `/users/${user.userId}`)}>
           <Avatar
             name={user.nickname}
             src={user.imageUrl || undefined}

--- a/src/pages/users/UserProfilePage.tsx
+++ b/src/pages/users/UserProfilePage.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Users, TrendingUp, Loader2, ChevronLeft } from "lucide-react";
+import Avatar from "@/components/ui/Avatar";
+import Button from "@/components/ui/Button";
+import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
+import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
+import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
+import PortfolioTab from "@/components/profile/PortfolioTab";
+import {
+  useUserProfileQuery,
+  useMentorHoldingsQuery,
+  useMentorDiariesQuery,
+  useMentorTradeHistoryQuery,
+} from "@/api/mentorApi";
+import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TABS = [
+  { id: "diary", label: "매매일지" },
+  { id: "history", label: "매매내역" },
+  { id: "portfolio", label: "포트폴리오" },
+] as const;
+
+type TabId = (typeof TABS)[number]["id"];
+
+function fmtAmount(n: number) {
+  if (Math.abs(n) >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}억`;
+  if (Math.abs(n) >= 10_000) return `${(n / 10_000).toFixed(0)}만원`;
+  return `${n.toLocaleString()}원`;
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function UserProfilePage() {
+  const { userId } = useParams<{ userId: string }>();
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<TabId>("diary");
+
+  const id = Number(userId);
+  const { data: profile, isLoading } = useUserProfileQuery(id);
+  const { data: summary } = useAccountSummaryByUserQuery(id);
+  const { data: holdingsRaw = [] } = useMentorHoldingsQuery(id);
+  const { data: diaries = [] } = useMentorDiariesQuery(id);
+  const { data: tradeHistories = [] } = useMentorTradeHistoryQuery(id);
+
+  const holdings = holdingsRaw.map((h) => ({
+    tickerCode: h.tickerCode,
+    stockName: h.stockName,
+    stockLogo: h.stockLogo,
+    quantity: h.quantity,
+    averageBuyPrice: 0,
+    currentPrice: h.currentPrice,
+    evaluationAmount: h.evaluation,
+    profitRate: h.returnRate,
+    profitAmount: h.returnAmount,
+  }));
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-screen">
+        <Loader2 size={32} className="animate-spin text-[#0046FF]" />
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="flex flex-col h-screen p-6 gap-5 bg-gray-50">
+        <button onClick={() => navigate(-1)} className="flex items-center gap-1 text-[14px] text-gray-500 hover:text-gray-700 w-fit">
+          <ChevronLeft size={16} />
+          뒤로
+        </button>
+        <div className="flex-1 flex items-center justify-center text-[14px] text-gray-400">
+          유저를 찾을 수 없습니다.
+        </div>
+      </div>
+    );
+  }
+
+  const isPositive = (summary?.totalReturnRate ?? 0) >= 0;
+
+  return (
+    <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50">
+      {/* 헤더 */}
+      <div className="flex items-center gap-3 shrink-0">
+        <button onClick={() => navigate(-1)} className="text-gray-400 hover:text-gray-600 transition-colors">
+          <ChevronLeft size={22} />
+        </button>
+        <h1 className="text-[22px] font-bold text-gray-900">{profile.nickname}</h1>
+      </div>
+
+      {/* 프로필 카드 */}
+      <div className="bg-white rounded-2xl border border-gray-100 px-6 py-4 shrink-0">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-3 flex-1">
+            <Avatar name={profile.nickname} src={profile.imageUrl || undefined} size={52} />
+            <div className="flex flex-col gap-1">
+              <span className="text-[16px] font-bold text-gray-900">{profile.nickname}</span>
+              <div className="flex items-center gap-4 text-[13px] text-gray-500">
+                <div className="flex items-center gap-1">
+                  <Users size={12} className="text-gray-400" />
+                  <span>팔로워</span>
+                  <span className="font-semibold text-gray-700 ml-0.5">{profile.followerCount.toLocaleString()}명</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <TrendingUp size={12} className="text-gray-400" />
+                  <span>총 수익률</span>
+                  <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+                    {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(1)}%
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span>총 수익</span>
+                  <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
+                    {isPositive ? "+" : ""}{fmtAmount(summary?.totalReturnAmount ?? 0)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {profile.following ? (
+              <Button variant="invalid" className="px-4 py-2 text-[13px]">팔로잉</Button>
+            ) : (
+              <Button variant="primary" className="px-4 py-2 text-[13px]">팔로우</Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 탭 + 콘텐츠 */}
+      <div className="flex-1 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
+        <UnderlineTabBar
+          tabs={[...TABS]}
+          activeId={activeTab}
+          onChange={(id) => setActiveTab(id as TabId)}
+        />
+        <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
+          {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
+          {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
+          {activeTab === "portfolio" && (
+            <PortfolioTab
+              totalEvaluation={summary?.totalEvaluation ?? 0}
+              totalReturnRate={summary?.totalReturnRate ?? 0}
+              totalReturnAmount={summary?.totalReturnAmount ?? 0}
+              portfolio={summary?.holdingsRatio ?? []}
+              holdings={holdings}
+              compact={false}
+              showAvgPrice={false}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -15,6 +15,7 @@ import AccountPage from "@/pages/account/AccountPage";
 import NotificationPage from "@/pages/notification/NotificationPage";
 import MyMentorPage from "@/pages/mentor/MyMentorPage";
 import MyMenteePage from "@/pages/mentee/MyMenteePage";
+import UserProfilePage from "@/pages/users/UserProfilePage";
 
 export const router = createBrowserRouter([
   {
@@ -43,7 +44,7 @@ export const router = createBrowserRouter([
           },
           { path: "users", element: <UserListPage /> },
           { path: "notifications", element: <NotificationPage /> },
-          { path: "users/:userId", element: <div /> },
+          { path: "users/:userId", element: <UserProfilePage /> },
           { path: "mentor", element: <MyMentorPage /> },
           { path: "mentee", element: <MyMenteePage /> },
         ],


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #43 

## 💡 작업 배경
  홈 화면과 유저 목록에서 항목을 클릭해도 이동이 되지 않아 사용성이 떨어졌고,
  타인 프로필 페이지가 없어 프로필 보기 버튼이 동작하지 않았음                  
                                                                                

  ## 🧩 작업 내용                                                               
  - `/users/:userId` 유저 프로필 페이지 구현                                    
    - 프로필 카드 (팔로워, 총 수익률, 총 수익, 팔로우 버튼)                     
    - 매매일지 / 매매내역 / 포트폴리오 탭                                       
    - 뒤로가기 버튼                                                             
  - 홈 TOP 투자자 클릭 → 해당 유저 프로필 이동                                  
  - 홈 보유 종목 행 클릭 → 종목 상세 페이지 이동                                
  - 유저 목록 포디움 클릭 → 해당 유저 프로필 이동                               
  - 유저 목록 테이블 닉네임 클릭 → 해당 유저 프로필 이동                        
  - 본인 항목 클릭 시 `/profile`로 이동 

## 📸 스크린샷(선택)


## 📝 기타