### PR TITLE
[Fix]  탈퇴시 로그인 타입별 분기 

### DIFF
--- a/src/api/userListApi.ts
+++ b/src/api/userListApi.ts
@@ -96,6 +96,7 @@ export type MyProfile = {
   imageUrl: string;
   followerCount: number;
   followingCount: number;
+  provider: "EMAIL" | "GOOGLE";
 };
 
 export function useMyProfileQuery() {

--- a/src/components/profile/DeleteAccountModal.tsx
+++ b/src/components/profile/DeleteAccountModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { X } from "lucide-react";
 import Button from "@/components/ui/Button";
 import { fetchClient } from "@/lib/fetchClient";
+import { useMyProfileQuery } from "@/api/userListApi";
 import type { ApiResponse } from "@/api/authApi";
 
 type Props = {
@@ -10,20 +11,30 @@ type Props = {
 };
 
 export default function DeleteAccountModal({ onClose, onDeleted }: Props) {
+  const { data: myProfile } = useMyProfileQuery();
+  const isGoogle = myProfile?.provider === "GOOGLE";
+
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
   const handleDelete = async () => {
-    if (!password.trim()) return;
+    if (!isGoogle && !password.trim()) return;
     setLoading(true);
     setError("");
     try {
-      await fetchClient.post<ApiResponse<void>>("/api/users/password/check", { password });
-      await fetchClient.delete<ApiResponse<void>>("/api/users");
+      await fetchClient.delete<ApiResponse<void>>(
+        "/api/users",
+        isGoogle ? {} : { password },
+      );
       onDeleted();
-    } catch {
-      setError("비밀번호가 올바르지 않아요.");
+    } catch (err: unknown) {
+      const msg = (err as Error)?.message ?? "";
+      if (msg.includes("400")) {
+        setError("비밀번호가 올바르지 않아요.");
+      } else {
+        setError("탈퇴 처리에 실패했어요. 다시 시도해주세요.");
+      }
     } finally {
       setLoading(false);
     }
@@ -41,27 +52,45 @@ export default function DeleteAccountModal({ onClose, onDeleted }: Props) {
         </div>
 
         <div className="px-6 py-6 flex flex-col gap-4">
-          <div>
-            <p className="text-[14px] text-gray-700 font-medium mb-1">탈퇴 전 본인 확인이 필요해요</p>
-            <p className="text-[13px] text-gray-400">비밀번호를 입력하면 계정이 영구적으로 삭제돼요.</p>
-          </div>
+          {isGoogle ? (
+            <div>
+              <p className="text-[14px] text-gray-700 font-medium mb-1">정말 탈퇴하시겠어요?</p>
+              <p className="text-[13px] text-gray-400">탈퇴 후 계정 정보는 영구적으로 삭제돼요.</p>
+            </div>
+          ) : (
+            <div>
+              <p className="text-[14px] text-gray-700 font-medium mb-1">탈퇴 전 본인 확인이 필요해요</p>
+              <p className="text-[13px] text-gray-400">비밀번호를 입력하면 계정이 영구적으로 삭제돼요.</p>
+            </div>
+          )}
 
-          <div>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => { setPassword(e.target.value); setError(""); }}
-              placeholder="비밀번호를 입력해주세요"
-              className="w-full border border-gray-200 rounded-xl px-3.5 py-2.5 text-[14px] outline-none focus:border-red-400 transition-colors"
-              onKeyDown={(e) => e.key === "Enter" && handleDelete()}
-            />
-            {error && <p className="text-[12px] text-red-500 mt-1.5">{error}</p>}
-          </div>
+          {!isGoogle && (
+            <div>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => { setPassword(e.target.value); setError(""); }}
+                placeholder="비밀번호를 입력해주세요"
+                className="w-full border border-gray-200 rounded-xl px-3.5 py-2.5 text-[14px] outline-none focus:border-red-400 transition-colors"
+                onKeyDown={(e) => e.key === "Enter" && handleDelete()}
+              />
+              {error && <p className="text-[12px] text-red-500 mt-1.5">{error}</p>}
+            </div>
+          )}
+
+          {isGoogle && error && (
+            <p className="text-[12px] text-red-500">{error}</p>
+          )}
         </div>
 
         <div className="flex gap-2 px-6 pb-6">
           <Button variant="invalid" className="flex-1 py-2.5" onClick={onClose}>취소</Button>
-          <Button variant="danger" className="flex-1 py-2.5" onClick={handleDelete} disabled={!password || loading}>
+          <Button
+            variant="danger"
+            className="flex-1 py-2.5"
+            onClick={handleDelete}
+            disabled={(!isGoogle && !password) || loading}
+          >
             {loading ? "처리 중..." : "탈퇴하기"}
           </Button>
         </div>

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -73,7 +73,7 @@ export default function LoginPage() {
         email: form.email,
         password: form.password,
       });
-      setAuth(res.data.accessToken, { nickname: res.data.nickname });
+      setAuth(res.data.accessToken, { nickname: res.data.nickname, provider: "EMAIL" });
       navigate("/");
     } catch {
       setErrorMsg("이메일 또는 비밀번호가 올바르지 않습니다.");

--- a/src/pages/auth/OauthCallbackPage.tsx
+++ b/src/pages/auth/OauthCallbackPage.tsx
@@ -26,7 +26,7 @@ export default function OAuthCallbackPage() {
       .googleCallback(code)
       .then((res) => {
         console.log("[OAuth] 응답:", res);
-        setAuth(res.data.accessToken, { nickname: res.data.nickname });
+        setAuth(res.data.accessToken, { nickname: res.data.nickname, provider: "GOOGLE" });
         navigate("/", { replace: true });
       })
       .catch((err) => {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -5,6 +5,7 @@ import { persist, createJSONStorage } from "zustand/middleware";
 export interface AuthUser {
   nickname: string;
   imageUrl?: string;
+  provider?: "EMAIL" | "GOOGLE";
 }
 
 interface AuthState {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #68 

## 💡 작업 배경
탈퇴시 로그인 타입별 분기가 필요하다. 현재 로직이 똑같아, 구글 로그인시 탈퇴 처리를 못하고 있다.

## 🧩 작업 내용
- api 변동으로 provider 연동
- 로그인 타입 별로 탈퇴 로직 분기
  - 일반: 비밀번호 입력
  - 구글: 탈퇴 문구만

## 📸 스크린샷(선택)
<img width="1192" height="871" alt="Screenshot 2026-03-27 at 10 14 43 AM" src="https://github.com/user-attachments/assets/c804d9f3-1c0b-49f1-ab05-4017493c732c" />


## 📝 기타