### PR TITLE
[Feat] 프로필 이미지 종류, 용량 안내 문구 추가

### DIFF
--- a/src/components/profile/EditProfileModal.tsx
+++ b/src/components/profile/EditProfileModal.tsx
@@ -22,6 +22,7 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
   const [checking, setChecking] = useState(false);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -53,6 +54,12 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    if (file.size > 2 * 1024 * 1024) {
+      setImageError("이미지는 2MB 이하만 업로드할 수 있어요.");
+      e.target.value = "";
+      return;
+    }
+    setImageError(null);
     setImageFile(file);
     setImagePreview(URL.createObjectURL(file));
   };
@@ -88,6 +95,7 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
   const nicknameUnchanged = nicknameValue === nickname;
   const canSave =
     nicknameValue.trim() &&
+    !imageError &&
     (nicknameUnchanged || (nicknameChecked && nicknameMsg?.ok !== false));
 
   const displayImage = imagePreview ?? profileImageUrl ?? undefined;
@@ -129,12 +137,9 @@ export default function EditProfileModal({ nickname, profileImageUrl, onClose, o
                 <Camera size={11} className="text-white" />
               </div>
             </button>
-            <button
-              onClick={() => fileRef.current?.click()}
-              className="text-[12px] text-[#0046FF] font-medium hover:underline"
-            >
-              사진 변경
-            </button>
+            <p></p>
+            <p className="text-[11px] text-gray-400">최대 2MB JPG, JPEG, PNG만 가능합니다.</p>
+            {imageError && <p className="text-[11px] text-red-500">{imageError}</p>}
             <input ref={fileRef} type="file" accept="image/*" className="hidden" onChange={handleImageChange} />
           </div>
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #63 

## 💡 작업 배경
- 프로필 이미지 종류, 용량 안내 문구 추가가 없어 사용자가 혼란이 생길 가능성이 있다.

## 🧩 작업 내용
- 프로필 이미지 종류, 용량 안내 문구 추가

## 📸 스크린샷(선택)
<img width="569" height="482" alt="Screenshot 2026-03-27 at 10 36 12 AM" src="https://github.com/user-attachments/assets/97b8c1f7-edf0-493c-9406-314ca69f0e77" />


## 📝 기타