### PR TITLE
[Refactor] 타인 유저 프로필 카드 추가 및 팔로우 UI/캐시 개선

### DIFF
--- a/src/api/userListApi.ts
+++ b/src/api/userListApi.ts
@@ -66,7 +66,9 @@ export function useUserListCacheUpdate() {
     updateCache((old) => ({
       ...old,
       users: old.users.map((u) =>
-        u.userId === userId ? { ...u, following: newFollowing } : u,
+        u.userId === userId
+          ? { ...u, following: newFollowing, followerCount: u.followerCount + (newFollowing ? 1 : -1) }
+          : u,
       ),
     }));
   }
@@ -153,6 +155,38 @@ export function useFollowingInfiniteQuery() {
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage) =>
       lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
+  });
+}
+
+export function useUserFollowersInfiniteQuery(userId: number) {
+  return useInfiniteQuery({
+    queryKey: ["follows", userId, "followers"],
+    queryFn: ({ pageParam }) => {
+      const params = pageParam !== undefined ? `?cursor=${pageParam}` : "";
+      return fetchClient
+        .get<ApiResponse<FollowListData>>(`/api/users/${userId}/followers${params}`)
+        .then((res) => res.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
+    enabled: !!userId,
+  });
+}
+
+export function useUserFollowingInfiniteQuery(userId: number) {
+  return useInfiniteQuery({
+    queryKey: ["follows", userId, "following"],
+    queryFn: ({ pageParam }) => {
+      const params = pageParam !== undefined ? `?cursor=${pageParam}` : "";
+      return fetchClient
+        .get<ApiResponse<FollowListData>>(`/api/users/${userId}/following${params}`)
+        .then((res) => res.data);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
+    enabled: !!userId,
   });
 }
 

--- a/src/components/profile/FollowList.tsx
+++ b/src/components/profile/FollowList.tsx
@@ -1,22 +1,35 @@
 import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import Avatar from "@/components/ui/Avatar";
 import {
+  useMyProfileQuery,
   useFollowersInfiniteQuery,
   useFollowingInfiniteQuery,
+  useUserFollowersInfiniteQuery,
+  useUserFollowingInfiniteQuery,
 } from "@/api/userListApi";
 
 type Props = {
   type: "followers" | "following";
+  userId?: number;
 };
 
 const LABEL = { followers: "팔로워", following: "팔로잉" };
+const EMPTY_LABEL = { followers: "팔로워가 없습니다.", following: "팔로잉이 없습니다." };
 
-export default function FollowList({ type }: Props) {
+export default function FollowList({ type, userId }: Props) {
+  const navigate = useNavigate();
+  const { data: me } = useMyProfileQuery();
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  const followersQuery = useFollowersInfiniteQuery();
-  const followingQuery = useFollowingInfiniteQuery();
-  const query = type === "followers" ? followersQuery : followingQuery;
+  const myFollowersQuery = useFollowersInfiniteQuery();
+  const myFollowingQuery = useFollowingInfiniteQuery();
+  const userFollowersQuery = useUserFollowersInfiniteQuery(userId ?? 0);
+  const userFollowingQuery = useUserFollowingInfiniteQuery(userId ?? 0);
+
+  const query = userId
+    ? type === "followers" ? userFollowersQuery : userFollowingQuery
+    : type === "followers" ? myFollowersQuery : myFollowingQuery;
 
   const items = query.data?.pages.flatMap((p) => p.users) ?? [];
 
@@ -39,14 +52,15 @@ export default function FollowList({ type }: Props) {
       <p className="text-[13px] font-semibold text-gray-700 px-4 pt-4 pb-2">{LABEL[type]}</p>
       {items.length === 0 && !query.isLoading ? (
         <div className="flex items-center justify-center py-10">
-          <p className="text-[12px] text-gray-400">{LABEL[type]}이 없습니다.</p>
+          <p className="text-[12px] text-gray-400">{EMPTY_LABEL[type]}</p>
         </div>
       ) : (
         <div className="flex flex-col pb-2">
           {items.map((user) => (
             <div
               key={user.userId}
-              className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors"
+              onClick={() => user.userId === me?.userId ? navigate("/profile") : navigate(`/users/${user.userId}`)}
+              className="flex items-center gap-3 px-4 py-2.5 hover:bg-gray-50 transition-colors cursor-pointer"
             >
               <Avatar name={user.nickname} src={user.imageUrl} size={32} />
               <span className="text-[13px] font-medium text-gray-800">{user.nickname}</span>

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -23,6 +23,7 @@ type Props = {
   // 타인 프로필
   isFollowing?: boolean;
   onFollowClick?: () => void;
+  badge?: "멘토" | "멘티";
 };
 
 function fmtAmount(n: number) {
@@ -47,6 +48,7 @@ export default function ProfileCard({
   onDeleteClick,
   isFollowing,
   onFollowClick,
+  badge,
 }: Props) {
   const isPositive = totalReturnRate >= 0;
 
@@ -57,7 +59,15 @@ export default function ProfileCard({
         <div className="mb-3">
           <Avatar name={nickname} src={profileImageUrl ?? undefined} size={80} />
         </div>
-        <h2 className="text-[17px] font-bold text-gray-900">{nickname}</h2>
+        <div className="flex items-center gap-2 mt-1">
+          <h2 className="text-[17px] font-bold text-gray-900">{nickname}</h2>
+          {badge === "멘토" && (
+            <span className="text-[11px] font-semibold text-amber-600 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded-full">멘토</span>
+          )}
+          {badge === "멘티" && (
+            <span className="text-[11px] font-semibold text-blue-600 bg-blue-50 border border-blue-200 px-2 py-0.5 rounded-full">멘티</span>
+          )}
+        </div>
         {email && (
           <p className="text-[13px] text-gray-400 mt-0.5">{email}</p>
         )}

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -11,11 +11,18 @@ type Props = {
   following: number;
   totalReturnRate: number;
   totalReturn: number;
-  onEditClick: () => void;
-  onLogoutClick: () => void;
-  onDeleteClick: () => void;
   onFollowersClick: () => void;
   onFollowingClick: () => void;
+
+  // 내 프로필
+  isOwnProfile?: boolean;
+  onEditClick?: () => void;
+  onLogoutClick?: () => void;
+  onDeleteClick?: () => void;
+
+  // 타인 프로필
+  isFollowing?: boolean;
+  onFollowClick?: () => void;
 };
 
 function fmtAmount(n: number) {
@@ -32,11 +39,14 @@ export default function ProfileCard({
   following,
   totalReturnRate,
   totalReturn,
+  onFollowersClick,
+  onFollowingClick,
+  isOwnProfile = true,
   onEditClick,
   onLogoutClick,
   onDeleteClick,
-  onFollowersClick,
-  onFollowingClick,
+  isFollowing,
+  onFollowClick,
 }: Props) {
   const isPositive = totalReturnRate >= 0;
 
@@ -76,42 +86,44 @@ export default function ProfileCard({
       <div className="grid grid-cols-2 gap-2 pt-4 border-t border-gray-100 mb-4">
         <div className="text-center">
           <p className="text-[12px] text-gray-400 mb-1">수익률</p>
-          <p
-            className={`text-[13px] font-bold ${
-              isPositive ? "text-[#FF4444]" : "text-[#0046FF]"
-            }`}
-          >
-            {isPositive ? "+" : ""}
-            {totalReturnRate.toFixed(1)}%
+          <p className={`text-[13px] font-bold ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
+            {isPositive ? "+" : ""}{totalReturnRate.toFixed(1)}%
           </p>
         </div>
         <div className="text-center">
           <p className="text-[12px] text-gray-400 mb-1">총 수익</p>
-          <p
-            className={`text-[13px] font-bold ${
-              isPositive ? "text-[#FF4444]" : "text-[#0046FF]"
-            }`}
-          >
-            {isPositive ? "+" : ""}
-            {fmtAmount(totalReturn)}원
+          <p className={`text-[13px] font-bold ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
+            {isPositive ? "+" : ""}{fmtAmount(totalReturn)}원
           </p>
         </div>
       </div>
 
       {/* 액션 버튼 */}
       <div className="space-y-2 pt-4 border-t border-gray-100">
-        <Button variant="invalid" className="w-full flex items-center justify-center gap-2" onClick={onEditClick}>
-          <Settings size={14} />
-          프로필 편집
-        </Button>
-        <Button variant="invalid" className="w-full flex items-center justify-center gap-2" onClick={onLogoutClick}>
-          <LogOut size={14} />
-          로그아웃
-        </Button>
-        <Button variant="danger" className="w-full flex items-center justify-center gap-2" onClick={onDeleteClick}>
-          <Trash2 size={14} />
-          회원탈퇴
-        </Button>
+        {isOwnProfile ? (
+          <>
+            <Button variant="invalid" className="w-full flex items-center justify-center gap-2" onClick={onEditClick}>
+              <Settings size={14} />
+              프로필 편집
+            </Button>
+            <Button variant="invalid" className="w-full flex items-center justify-center gap-2" onClick={onLogoutClick}>
+              <LogOut size={14} />
+              로그아웃
+            </Button>
+            <Button variant="danger" className="w-full flex items-center justify-center gap-2" onClick={onDeleteClick}>
+              <Trash2 size={14} />
+              회원탈퇴
+            </Button>
+          </>
+        ) : (
+          <Button
+            variant={isFollowing ? "invalid" : "primary"}
+            className="w-full"
+            onClick={onFollowClick}
+          >
+            {isFollowing ? "팔로잉" : "팔로우"}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,3 +1,14 @@
+const AVATAR_COLORS = [
+  "#4ECDC4", "#45B7D1", "#FF6B35", "#96CEB4", "#DDA0DD",
+  "#BB8FCE", "#85C1E9", "#F0A500", "#E74C3C", "#2ECC71",
+];
+
+function getAvatarColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
 type AvatarProps = {
   name: string;
   color?: string;
@@ -25,13 +36,14 @@ function getInitials(name: string): string {
 
 export default function Avatar({
   name,
-  color = "#0046FF",
+  color,
   size = 40,
   src,
   className = "",
   onClick,
 }: AvatarProps) {
   const initials = getInitials(name);
+  const bgColor = color ?? getAvatarColor(name);
 
   // 이미지 아바타
   if (src) {
@@ -55,7 +67,7 @@ export default function Avatar({
     <div
       className="rounded-full flex items-center justify-center shrink-0 select-none object-cover"
       style={{
-        background: color,
+        background: bgColor,
         color: "#ffffff",
         width: `${size}px`,
         height: `${size}px`,

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Search } from "lucide-react";
-import { useQueries } from "@tanstack/react-query";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
 import {
@@ -278,6 +278,7 @@ export default function UserListPage() {
 
   const { data, isLoading } = useUserListQuery();
   const { toggleFollow, setMentoringStatus } = useUserListCacheUpdate();
+  const queryClient = useQueryClient();
 
   const allUsers = data?.users ?? [];
   const hasAcceptedMentor = data?.hasAcceptedMentor ?? false;
@@ -307,6 +308,9 @@ export default function UserListPage() {
       } else {
         await followUser(user.userId);
       }
+      queryClient.invalidateQueries({ queryKey: ["users", "me"] });
+      queryClient.invalidateQueries({ queryKey: ["follows", user.userId, "followers"] });
+      queryClient.invalidateQueries({ queryKey: ["follows", "following"] });
     } catch {
       toggleFollow(user.userId, user.following);
     }

--- a/src/pages/users/UserProfilePage.tsx
+++ b/src/pages/users/UserProfilePage.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Users, TrendingUp, Loader2, ChevronLeft } from "lucide-react";
-import Avatar from "@/components/ui/Avatar";
-import Button from "@/components/ui/Button";
+import { Loader2, ChevronLeft } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
 import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
 import TradeHistoryTab from "@/components/profile/TradeHistoryTab";
 import PortfolioTab from "@/components/profile/PortfolioTab";
+import ProfileCard from "@/components/profile/ProfileCard";
+import FollowList from "@/components/profile/FollowList";
 import {
   useUserProfileQuery,
   useMentorHoldingsQuery,
@@ -14,6 +15,7 @@ import {
   useMentorTradeHistoryQuery,
 } from "@/api/mentorApi";
 import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
+import { followUser, unfollowUser } from "@/api/userListApi";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -25,18 +27,14 @@ const TABS = [
 
 type TabId = (typeof TABS)[number]["id"];
 
-function fmtAmount(n: number) {
-  if (Math.abs(n) >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}억`;
-  if (Math.abs(n) >= 10_000) return `${(n / 10_000).toFixed(0)}만원`;
-  return `${n.toLocaleString()}원`;
-}
-
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function UserProfilePage() {
   const { userId } = useParams<{ userId: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<TabId>("diary");
+  const [followModal, setFollowModal] = useState<"followers" | "following" | null>("following");
 
   const id = Number(userId);
   const { data: profile, isLoading } = useUserProfileQuery(id);
@@ -56,6 +54,23 @@ export default function UserProfilePage() {
     profitRate: h.returnRate,
     profitAmount: h.returnAmount,
   }));
+
+  const handleFollow = async () => {
+    if (!profile) return;
+    try {
+      if (profile.following) {
+        await unfollowUser(id);
+      } else {
+        await followUser(id);
+      }
+      queryClient.invalidateQueries({ queryKey: ["users", id] });
+      queryClient.invalidateQueries({ queryKey: ["users", "me"] });
+      queryClient.invalidateQueries({ queryKey: ["follows", id, "followers"] });
+      queryClient.invalidateQueries({ queryKey: ["follows", "following"] });
+    } catch (e) {
+      // 실패 시 무시
+    }
+  };
 
   if (isLoading) {
     return (
@@ -79,8 +94,6 @@ export default function UserProfilePage() {
     );
   }
 
-  const isPositive = (summary?.totalReturnRate ?? 0) >= 0;
-
   return (
     <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50">
       {/* 헤더 */}
@@ -91,66 +104,49 @@ export default function UserProfilePage() {
         <h1 className="text-[22px] font-bold text-gray-900">{profile.nickname}</h1>
       </div>
 
-      {/* 프로필 카드 */}
-      <div className="bg-white rounded-2xl border border-gray-100 px-6 py-4 shrink-0">
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-3 flex-1">
-            <Avatar name={profile.nickname} src={profile.imageUrl || undefined} size={52} />
-            <div className="flex flex-col gap-1">
-              <span className="text-[16px] font-bold text-gray-900">{profile.nickname}</span>
-              <div className="flex items-center gap-4 text-[13px] text-gray-500">
-                <div className="flex items-center gap-1">
-                  <Users size={12} className="text-gray-400" />
-                  <span>팔로워</span>
-                  <span className="font-semibold text-gray-700 ml-0.5">{profile.followerCount.toLocaleString()}명</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <TrendingUp size={12} className="text-gray-400" />
-                  <span>총 수익률</span>
-                  <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-                    {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(1)}%
-                  </span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <span>총 수익</span>
-                  <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-                    {isPositive ? "+" : ""}{fmtAmount(summary?.totalReturnAmount ?? 0)}
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            {profile.following ? (
-              <Button variant="invalid" className="px-4 py-2 text-[13px]">팔로잉</Button>
-            ) : (
-              <Button variant="primary" className="px-4 py-2 text-[13px]">팔로우</Button>
+      <div className="flex gap-5 flex-1 min-h-0">
+        {/* 왼쪽: 프로필 카드 + 팔로워/팔로잉 목록 */}
+        <div className="w-64 shrink-0 overflow-y-auto h-full flex flex-col">
+          <ProfileCard
+            isOwnProfile={false}
+            isFollowing={profile.following}
+            onFollowClick={handleFollow}
+            nickname={profile.nickname}
+            profileImageUrl={profile.imageUrl}
+            followers={profile.followerCount}
+            following={profile.followingCount}
+            totalReturnRate={summary?.totalReturnRate ?? 0}
+            totalReturn={summary?.totalReturnAmount ?? 0}
+            onFollowersClick={() => setFollowModal("followers")}
+            onFollowingClick={() => setFollowModal("following")}
+          />
+          {followModal && (
+            <FollowList type={followModal} userId={id} />
+          )}
+        </div>
+
+        {/* 오른쪽: 탭 + 콘텐츠 */}
+        <div className="flex-1 min-w-0 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
+          <UnderlineTabBar
+            tabs={[...TABS]}
+            activeId={activeTab}
+            onChange={(id) => setActiveTab(id as TabId)}
+          />
+          <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
+            {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
+            {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
+            {activeTab === "portfolio" && (
+              <PortfolioTab
+                totalEvaluation={summary?.totalEvaluation ?? 0}
+                totalReturnRate={summary?.totalReturnRate ?? 0}
+                totalReturnAmount={summary?.totalReturnAmount ?? 0}
+                portfolio={summary?.holdingsRatio ?? []}
+                holdings={holdings}
+                compact={false}
+                showAvgPrice={false}
+              />
             )}
           </div>
-        </div>
-      </div>
-
-      {/* 탭 + 콘텐츠 */}
-      <div className="flex-1 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
-        <UnderlineTabBar
-          tabs={[...TABS]}
-          activeId={activeTab}
-          onChange={(id) => setActiveTab(id as TabId)}
-        />
-        <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
-          {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
-          {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
-          {activeTab === "portfolio" && (
-            <PortfolioTab
-              totalEvaluation={summary?.totalEvaluation ?? 0}
-              totalReturnRate={summary?.totalReturnRate ?? 0}
-              totalReturnAmount={summary?.totalReturnAmount ?? 0}
-              portfolio={summary?.holdingsRatio ?? []}
-              holdings={holdings}
-              compact={false}
-              showAvgPrice={false}
-            />
-          )}
         </div>
       </div>
     </div>

--- a/src/pages/users/UserProfilePage.tsx
+++ b/src/pages/users/UserProfilePage.tsx
@@ -13,6 +13,8 @@ import {
   useMentorHoldingsQuery,
   useMentorDiariesQuery,
   useMentorTradeHistoryQuery,
+  useMyMenteesQuery,
+  useMyMentorQuery,
 } from "@/api/mentorApi";
 import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
 import { followUser, unfollowUser } from "@/api/userListApi";
@@ -42,6 +44,8 @@ export default function UserProfilePage() {
   const { data: holdingsRaw = [] } = useMentorHoldingsQuery(id);
   const { data: diaries = [] } = useMentorDiariesQuery(id);
   const { data: tradeHistories = [] } = useMentorTradeHistoryQuery(id);
+  const { data: myMentor } = useMyMentorQuery();
+  const { data: myMentees } = useMyMenteesQuery();
 
   const holdings = holdingsRaw.map((h) => ({
     tickerCode: h.tickerCode,
@@ -54,6 +58,9 @@ export default function UserProfilePage() {
     profitRate: h.returnRate,
     profitAmount: h.returnAmount,
   }));
+
+  const isMentor = myMentor?.hasMentor && myMentor.userId === id;
+  const isMentee = myMentees?.mentees.some((m) => m.userId === id);
 
   const handleFollow = async () => {
     if (!profile) return;
@@ -119,6 +126,7 @@ export default function UserProfilePage() {
             totalReturn={summary?.totalReturnAmount ?? 0}
             onFollowersClick={() => setFollowModal("followers")}
             onFollowingClick={() => setFollowModal("following")}
+            badge={isMentor ? "멘토" : isMentee ? "멘티" : undefined}
           />
           {followModal && (
             <FollowList type={followModal} userId={id} />


### PR DESCRIPTION
## #️⃣  관련 이슈                          
 - closed #72
                                                                                                                
  ## 💡 작업 배경
  타인 유저 프로필 페이지에 프로필 카드가 없어 내 프로필 페이지와 UI/UX가 일관되지 않았고,                      
  팔로우 관련 캐시 미갱신 및 아바타 색상 불일치 문제가 있었음                                                   
                                                                                                                
  ## 🧩 작업 내용                                                                                               
  - 타인 유저 프로필 페이지를 내 프로필과 동일한 2-column 레이아웃으로 변경                                     
  - ProfileCard에 `isOwnProfile` prop 추가 — 타인 프로필에서는 편집/로그아웃/탈퇴 대신 팔로우/팔로잉 버튼 표시  
  - ProfileCard에 멘토/멘티 뱃지 추가 (닉네임 옆)                                                               
  - 타인 팔로워/팔로잉 조회 API 추가 (`/api/users/{userId}/followers`, `/api/users/{userId}/following`)         
  - FollowList에 `userId` prop 추가 — 타인 팔로워/팔로잉 목록 조회 지원                                         
  - FollowList 항목 클릭 시 해당 유저 프로필로 이동, 본인 클릭 시 `/profile`로 이동                             
  - 팔로우/언팔로우 후 팔로워 수 및 팔로우 목록 캐시 즉시 갱신                                                  
  - Avatar 컴포넌트에 닉네임 기반 색상 자동 생성 로직 추가 — 모든 화면에서 동일한 색상 표시                     
  - 빈 상태 메시지 오타 수정 (팔로워이 → 팔로워가)                                                              
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
  ## 📝 기타 