### PR TITLE
[Feat] 코치마크 구현

### DIFF
--- a/src/api/homeApi.ts
+++ b/src/api/homeApi.ts
@@ -158,6 +158,6 @@ export function useMarketIndicesQuery() {
           console.error("[market] error:", err);
           throw err;
         }),
-    staleTime: 10_000,
+    staleTime: 60_000,
   });
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,13 +11,30 @@ import {
 import type { MarketIndexData, MarketIndicatorMessage } from "@/api/homeApi";
 import Sidebar from "./Sidebar";
 import OnboardingOverlay from "@/components/onboarding/OnboardingOverlay";
-import SpotlightTour from "@/components/onboarding/SpotlightTour";
 import { useOnboardingStore } from "@/store/onboardingStore";
+import { useAuthStore } from "@/store/authStore";
+
+function parseJwtSub(token: string): string | null {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
+    return String(payload.sub ?? payload.userId ?? payload.id ?? "");
+  } catch {
+    return null;
+  }
+}
 
 export default function Layout() {
   const queryClient = useQueryClient();
+  const accessToken = useAuthStore((s) => s.accessToken);
   const hasSeenOnboarding = useOnboardingStore((s) => s.hasSeenOnboarding);
-  const hasSeenSpotlight = useOnboardingStore((s) => s.hasSeenSpotlight);
+  const init = useOnboardingStore((s) => s.init);
+
+  // JWT sub(userId)를 키로 유저별 온보딩 상태 불러오기
+  useEffect(() => {
+    if (!accessToken) return;
+    const userId = parseJwtSub(accessToken);
+    if (userId) init(userId);
+  }, [accessToken]);
 
   useEffect(() => {
     const wsUrl = (import.meta.env.VITE_API_BASE_URL ?? "") + "/ws";
@@ -28,12 +45,16 @@ export default function Layout() {
         client.subscribe("/topic/market/indicators", (message) => {
           const msg: MarketIndicatorMessage = JSON.parse(message.body);
           const updated = parseMarketIndicatorMessage(msg);
+          const prev = queryClient.getQueryData<MarketIndexData[]>(
+            homeQueryKeys.marketIndices,
+          );
+          // 캐시가 비어있으면 건드리지 않음 — 초기 REST 요청이 알아서 채움
+          if (!prev || prev.length === 0) return;
           queryClient.setQueryData<MarketIndexData[]>(
             homeQueryKeys.marketIndices,
-            (prev = []) =>
-              prev.map((item) =>
-                item.label === updated.label ? updated : item,
-              ),
+            prev.map((item) =>
+              item.label === updated.label ? updated : item,
+            ),
           );
         });
       },
@@ -51,7 +72,6 @@ export default function Layout() {
         <Outlet />
       </main>
       {!hasSeenOnboarding && <OnboardingOverlay />}
-      {hasSeenOnboarding && !hasSeenSpotlight && <SpotlightTour />}
       {import.meta.env.DEV && (
         <button
           className="fixed bottom-4 right-4 z-[999] bg-gray-800 text-white text-xs px-3 py-1.5 rounded-lg opacity-60 hover:opacity-100 transition-opacity"

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -10,9 +10,14 @@ import {
 } from "@/api/homeApi";
 import type { MarketIndexData, MarketIndicatorMessage } from "@/api/homeApi";
 import Sidebar from "./Sidebar";
+import OnboardingOverlay from "@/components/onboarding/OnboardingOverlay";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import { useOnboardingStore } from "@/store/onboardingStore";
 
 export default function Layout() {
   const queryClient = useQueryClient();
+  const hasSeenOnboarding = useOnboardingStore((s) => s.hasSeenOnboarding);
+  const hasSeenSpotlight = useOnboardingStore((s) => s.hasSeenSpotlight);
 
   useEffect(() => {
     const wsUrl = (import.meta.env.VITE_API_BASE_URL ?? "") + "/ws";
@@ -45,6 +50,19 @@ export default function Layout() {
       <main className="flex-1 overflow-auto">
         <Outlet />
       </main>
+      {!hasSeenOnboarding && <OnboardingOverlay />}
+      {hasSeenOnboarding && !hasSeenSpotlight && <SpotlightTour />}
+      {import.meta.env.DEV && (
+        <button
+          className="fixed bottom-4 right-4 z-[999] bg-gray-800 text-white text-xs px-3 py-1.5 rounded-lg opacity-60 hover:opacity-100 transition-opacity"
+          onClick={() => {
+            localStorage.removeItem("solmate-onboarding");
+            window.location.reload();
+          }}
+        >
+          🔄 온보딩 초기화
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -27,7 +27,6 @@ export default function Layout() {
   const queryClient = useQueryClient();
   const accessToken = useAuthStore((s) => s.accessToken);
   const hasSeenOnboarding = useOnboardingStore((s) => s.hasSeenOnboarding);
-  const currentUserId = useOnboardingStore((s) => s.currentUserId);
   const init = useOnboardingStore((s) => s.init);
 
   // JWT sub(userId)를 키로 유저별 온보딩 상태 불러오기
@@ -73,19 +72,6 @@ export default function Layout() {
         <Outlet />
       </main>
       {!hasSeenOnboarding && <OnboardingOverlay />}
-      {import.meta.env.DEV && (
-        <button
-          className="fixed bottom-4 right-4 z-[999] bg-gray-800 text-white text-xs px-3 py-1.5 rounded-lg opacity-60 hover:opacity-100 transition-opacity"
-          onClick={() => {
-            if (currentUserId) {
-              localStorage.removeItem(`solmate-onboarding-${currentUserId}`);
-            }
-            window.location.reload();
-          }}
-        >
-          🔄 온보딩 초기화
-        </button>
-      )}
     </div>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -76,7 +76,7 @@ function NavItem({
     <li>
       <button
         onClick={onClick}
-        data-tour={item.id === "invest" ? "nav-invest" : undefined}
+        data-tour={["invest", "account", "trade", "users", "mentor", "profile"].includes(item.id) ? `nav-${item.id}` : undefined}
         className={[
           "relative w-full flex items-center gap-2.5 px-3 py-2.25 rounded-[10px]",
           "text-left transition-colors duration-150 group cursor-pointer",

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -75,6 +75,7 @@ function NavItem({
     <li>
       <button
         onClick={onClick}
+        data-tour={item.id === "invest" ? "nav-invest" : undefined}
         className={[
           "relative w-full flex items-center gap-2.5 px-3 py-2.25 rounded-[10px]",
           "text-left transition-colors duration-150 group cursor-pointer",

--- a/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/components/onboarding/OnboardingOverlay.tsx
@@ -13,30 +13,33 @@ const SLIDES: Slide[] = [
   {
     emoji: "👋",
     badge: "환영해요",
-    title: "솔메이트에 오신 걸\n환영해요!",
-    description: "실제 돈 없이 주식 투자를 경험할 수 있는\n모의투자 플랫폼이에요.",
-    highlight: "1,000만원의 가상 자금으로 지금 바로 시작할 수 있어요",
-  },
-  {
-    emoji: "📈",
-    badge: "주식",
-    title: "주식이 뭔가요?",
-    description: "회사의 일부를 소유하는 증서예요.\n회사가 성장하면 주식 가격도 함께 올라가요.",
-    highlight: "주식을 사는 걸 '매수', 파는 걸 '매도'라고 해요",
+    title: "Solmate에 오신 걸\n환영해요!",
+    description:
+      "가상 1,000만원으로 실전 같은 주식 투자를\n경험할 수 있는 모의투자 플랫폼이에요.",
+    highlight: "실제 코스피200 시세 그대로, 리스크 없이 시작",
   },
   {
     emoji: "💰",
-    badge: "시세 · 수익률",
-    title: "시세와 수익률이\n뭔가요?",
+    badge: "내 자산",
+    title: "예수금·평가자산을\n한눈에 확인해요",
     description:
-      "시세는 지금 실시간으로 거래되는 가격이에요.\n수익률은 내가 산 가격 대비 얼마나 올랐는지예요.",
-    highlight: "예) 10,000원에 샀는데 11,000원이면 수익률 +10% 📈",
+      "홈에서 총 평가자산과 예수금을 볼 수 있어요.\n예수금은 아직 투자하지 않은 내 현금이에요.",
+    highlight: "평가자산 = 예수금 + 보유 종목 평가금액",
   },
   {
-    emoji: "🚀",
-    badge: "시작!",
-    title: "준비 완료!\n이제 시작해볼까요?",
-    description: "투자 탭에서 마음에 드는 주식을 골라\n나만의 포트폴리오를 만들어봐요.",
+    emoji: "📊",
+    badge: "매수 · 매도",
+    title: "종목을 골라\n매수·매도 해봐요",
+    description:
+      "모의투자 탭에서 종목을 검색하고\n매수(사기)·매도(팔기)를 직접 해볼 수 있어요.",
+    highlight: "등락률 빨강 ▲ = 오름 / 파랑 ▼ = 내림 (한국 증시)",
+  },
+  {
+    emoji: "🏆",
+    badge: "랭킹 · 멘토",
+    title: "TOP 투자자와\n함께 성장해요",
+    description:
+      "수익률 상위 투자자의 포트폴리오를 보고 배우거나,\n멘토를 찾아 조언을 구할 수 있어요.",
   },
 ];
 
@@ -99,7 +102,9 @@ export default function OnboardingOverlay() {
         {/* 하이라이트 박스 */}
         {slide.highlight && (
           <div className="w-full mt-6 bg-blue-50 border border-blue-100 rounded-xl px-4 py-3">
-            <p className="text-sm text-[#0046FF] font-medium">{slide.highlight}</p>
+            <p className="text-sm text-[#0046FF] font-medium">
+              {slide.highlight}
+            </p>
           </div>
         )}
       </div>
@@ -134,7 +139,7 @@ export default function OnboardingOverlay() {
             className="flex-1 py-3 rounded-[10px] bg-[#0046FF] text-white text-sm font-medium hover:bg-[#0038CC] transition-colors"
             onClick={() => (isFinal ? markAsSeen() : transition(step + 1))}
           >
-            {isFinal ? "투자 시작하기" : "다음"}
+            {isFinal ? "앱 기능 둘러보기 →" : "다음"}
           </button>
         </div>
       </div>

--- a/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/components/onboarding/OnboardingOverlay.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { useOnboardingStore } from "@/store/onboardingStore";
+
+type Slide = {
+  emoji: string;
+  badge: string;
+  title: string;
+  description: string;
+  highlight?: string;
+};
+
+const SLIDES: Slide[] = [
+  {
+    emoji: "👋",
+    badge: "환영해요",
+    title: "솔메이트에 오신 걸\n환영해요!",
+    description: "실제 돈 없이 주식 투자를 경험할 수 있는\n모의투자 플랫폼이에요.",
+    highlight: "1,000만원의 가상 자금으로 지금 바로 시작할 수 있어요",
+  },
+  {
+    emoji: "📈",
+    badge: "주식",
+    title: "주식이 뭔가요?",
+    description: "회사의 일부를 소유하는 증서예요.\n회사가 성장하면 주식 가격도 함께 올라가요.",
+    highlight: "주식을 사는 걸 '매수', 파는 걸 '매도'라고 해요",
+  },
+  {
+    emoji: "💰",
+    badge: "시세 · 수익률",
+    title: "시세와 수익률이\n뭔가요?",
+    description:
+      "시세는 지금 실시간으로 거래되는 가격이에요.\n수익률은 내가 산 가격 대비 얼마나 올랐는지예요.",
+    highlight: "예) 10,000원에 샀는데 11,000원이면 수익률 +10% 📈",
+  },
+  {
+    emoji: "🚀",
+    badge: "시작!",
+    title: "준비 완료!\n이제 시작해볼까요?",
+    description: "투자 탭에서 마음에 드는 주식을 골라\n나만의 포트폴리오를 만들어봐요.",
+  },
+];
+
+export default function OnboardingOverlay() {
+  const markAsSeen = useOnboardingStore((s) => s.markAsSeen);
+  const [step, setStep] = useState(0);
+  const [visible, setVisible] = useState(true);
+
+  const slide = SLIDES[step];
+  const isFinal = step === SLIDES.length - 1;
+
+  const transition = (toStep: number) => {
+    setVisible(false);
+    setTimeout(() => {
+      setStep(toStep);
+      setVisible(true);
+    }, 180);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-between bg-white px-6 py-10">
+      {/* 상단: 건너뛰기 */}
+      <div className="w-full flex justify-end">
+        <button
+          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+          onClick={markAsSeen}
+        >
+          건너뛰기
+        </button>
+      </div>
+
+      {/* 중앙: 슬라이드 콘텐츠 */}
+      <div
+        className="flex-1 flex flex-col items-center justify-center text-center max-w-sm w-full transition-all duration-150"
+        style={{
+          opacity: visible ? 1 : 0,
+          transform: visible ? "translateY(0)" : "translateY(10px)",
+        }}
+      >
+        {/* 이모지 원형 */}
+        <div className="w-24 h-24 rounded-full bg-blue-50 flex items-center justify-center text-5xl mb-6">
+          {slide.emoji}
+        </div>
+
+        {/* 뱃지 */}
+        <span className="text-xs font-semibold text-[#0046FF] bg-blue-50 px-3 py-1 rounded-full mb-4">
+          {slide.badge}
+        </span>
+
+        {/* 제목 */}
+        <h2 className="text-2xl font-bold text-gray-900 whitespace-pre-line leading-snug mb-3">
+          {slide.title}
+        </h2>
+
+        {/* 설명 */}
+        <p className="text-sm text-gray-500 whitespace-pre-line leading-relaxed">
+          {slide.description}
+        </p>
+
+        {/* 하이라이트 박스 */}
+        {slide.highlight && (
+          <div className="w-full mt-6 bg-blue-50 border border-blue-100 rounded-xl px-4 py-3">
+            <p className="text-sm text-[#0046FF] font-medium">{slide.highlight}</p>
+          </div>
+        )}
+      </div>
+
+      {/* 하단: 도트 + 버튼 */}
+      <div className="w-full max-w-sm flex flex-col gap-5">
+        {/* 진행 도트 */}
+        <div className="flex justify-center items-center gap-2">
+          {SLIDES.map((_, i) => (
+            <div
+              key={i}
+              className="h-2 rounded-full transition-all duration-300"
+              style={{
+                width: i === step ? "24px" : "8px",
+                backgroundColor: i === step ? "#0046FF" : "#E5E7EB",
+              }}
+            />
+          ))}
+        </div>
+
+        {/* 버튼 */}
+        <div className="flex gap-3">
+          {step > 0 && (
+            <button
+              className="flex-1 py-3 rounded-[10px] border border-[#0046FF] text-[#0046FF] text-sm font-medium hover:bg-blue-50 transition-colors"
+              onClick={() => transition(step - 1)}
+            >
+              이전
+            </button>
+          )}
+          <button
+            className="flex-1 py-3 rounded-[10px] bg-[#0046FF] text-white text-sm font-medium hover:bg-[#0038CC] transition-colors"
+            onClick={() => (isFinal ? markAsSeen() : transition(step + 1))}
+          >
+            {isFinal ? "투자 시작하기" : "다음"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/SpotlightTour.tsx
+++ b/src/components/onboarding/SpotlightTour.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { HelpCircle } from "lucide-react";
 import { useOnboardingStore } from "@/store/onboardingStore";
 
 // ─── 상수 ──────────────────────────────────────────────────────────────────────
@@ -110,8 +111,11 @@ export default function SpotlightTour({ tourKey, steps }: Props) {
   const hasSeenOnboarding = useOnboardingStore((s) => s.hasSeenOnboarding);
   const seenTours = useOnboardingStore((s) => s.seenTours);
   const markTourSeen = useOnboardingStore((s) => s.markTourSeen);
+  const resetTour = useOnboardingStore((s) => s.resetTour);
 
   const hasSeen = !hasSeenOnboarding || (seenTours[tourKey] ?? false);
+  // 온보딩 완료 후 투어도 완료된 경우에만 재시작 버튼 표시
+  const canReplay = hasSeenOnboarding && (seenTours[tourKey] ?? false);
 
   const [stepIdx, setStepIdx] = useState(0);
   const [rect, setRect] = useState<DOMRect | null>(null);
@@ -178,7 +182,27 @@ export default function SpotlightTour({ tourKey, steps }: Props) {
     }
   };
 
-  if (hasSeen || !rect || !step) return null;
+  const handleReplay = () => {
+    setStepIdx(0);
+    setRect(null);
+    setTooltipVisible(false);
+    resetTour(tourKey);
+  };
+
+  if (hasSeen) {
+    if (!canReplay) return null;
+    return (
+      <button
+        className="animate-float fixed top-4 right-4 z-[999] w-11 h-11 bg-white rounded-full shadow-lg flex items-center justify-center text-[#0046FF] hover:bg-gray-50 transition-colors"
+        onClick={handleReplay}
+        title="가이드 다시보기"
+      >
+        <HelpCircle size={22} />
+      </button>
+    );
+  }
+
+  if (!rect || !step) return null;
 
   const dr = getDisplayRect(rect);
   const sp = SPOT_PADDING;

--- a/src/components/onboarding/SpotlightTour.tsx
+++ b/src/components/onboarding/SpotlightTour.tsx
@@ -3,137 +3,189 @@ import { useOnboardingStore } from "@/store/onboardingStore";
 
 // ─── 상수 ──────────────────────────────────────────────────────────────────────
 
-const SPOT_PADDING = 10; // 하이라이트 요소 주변 여백
-const TOOLTIP_GAP = 16;  // 스팟라이트 ~ 툴팁 사이 간격
+const SPOT_PADDING = 10;
+const TOOLTIP_GAP = 16;
 const TOOLTIP_WIDTH = 280;
 
-// ─── 스텝 정의 ─────────────────────────────────────────────────────────────────
+// ─── 타입 ──────────────────────────────────────────────────────────────────────
 
-type Placement = "bottom" | "top" | "right";
+type Placement = "bottom" | "top" | "right" | "left";
 
-type Step = {
+export type TourItem =
+  | string
+  | { label: string; labelColor: string; text: string };
+
+export type TourStep = {
   target: string;
   title: string;
   description: string;
+  items?: TourItem[];
   placement: Placement;
 };
 
-const STEPS: Step[] = [
-  {
-    target: "market-indices",
-    title: "시장 지수",
-    description: "코스피·코스닥·환율이 오늘 얼마나 움직였는지 실시간으로 보여줘요.",
-    placement: "bottom",
-  },
-  {
-    target: "portfolio",
-    title: "내 자산",
-    description: "가상 자금으로 얼마나 수익을 냈는지 한 눈에 확인할 수 있어요.",
-    placement: "bottom",
-  },
-  {
-    target: "holdings",
-    title: "보유 종목",
-    description: "내가 매수한 주식들의 현황이 여기에 표시돼요.",
-    placement: "top",
-  },
-  {
-    target: "nav-invest",
-    title: "모의투자",
-    description: "원하는 주식을 검색하고 매수·매도할 수 있어요. 지금 바로 눌러봐요!",
-    placement: "right",
-  },
-];
+type Props = {
+  tourKey: string;
+  steps: TourStep[];
+};
 
-// ─── 툴팁 위치 계산 ────────────────────────────────────────────────────────────
+// ─── 유틸 ──────────────────────────────────────────────────────────────────────
+
+function getDisplayRect(rect: DOMRect): DOMRect {
+  // 화면 아래로 삐져나가지 않도록 뷰포트 기준으로 높이 제한
+  const maxHeight = window.innerHeight - rect.top - 20;
+  const cappedHeight = Math.min(rect.height, Math.max(maxHeight, 80));
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: cappedHeight,
+    top: rect.top,
+    bottom: rect.top + cappedHeight,
+    left: rect.left,
+    right: rect.right,
+    toJSON: rect.toJSON,
+  };
+}
 
 function getTooltipPos(rect: DOMRect, placement: Placement): React.CSSProperties {
+  const TOOLTIP_EST_HEIGHT = 320;
   const clampedLeft = Math.min(
     Math.max(16, rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2),
     window.innerWidth - TOOLTIP_WIDTH - 16,
   );
+  const vh = window.innerHeight;
 
   switch (placement) {
-    case "bottom":
+    case "bottom": {
+      const spaceBelow = vh - rect.bottom - SPOT_PADDING - TOOLTIP_GAP;
+      const spaceAbove = rect.top - SPOT_PADDING - TOOLTIP_GAP;
+      // 아래 공간이 부족하면 위로 뒤집기
+      if (spaceBelow < TOOLTIP_EST_HEIGHT && spaceAbove > spaceBelow) {
+        return {
+          top: Math.max(16, rect.top - SPOT_PADDING - TOOLTIP_GAP - TOOLTIP_EST_HEIGHT),
+          left: clampedLeft,
+        };
+      }
       return {
-        top: rect.bottom + SPOT_PADDING + TOOLTIP_GAP,
+        top: Math.min(rect.bottom + SPOT_PADDING + TOOLTIP_GAP, vh - TOOLTIP_EST_HEIGHT - 16),
         left: clampedLeft,
       };
-    case "top":
-      // bottom 기준: 뷰포트 하단 → rect.top 위로
+    }
+    case "top": {
+      const spaceAbove = rect.top - SPOT_PADDING - TOOLTIP_GAP;
+      const spaceBelow = vh - rect.bottom - SPOT_PADDING - TOOLTIP_GAP;
+      // 위 공간이 부족하면 아래로 뒤집기
+      if (spaceAbove < TOOLTIP_EST_HEIGHT && spaceBelow > spaceAbove) {
+        return {
+          top: Math.min(rect.bottom + SPOT_PADDING + TOOLTIP_GAP, vh - TOOLTIP_EST_HEIGHT - 16),
+          left: clampedLeft,
+        };
+      }
       return {
-        bottom: window.innerHeight - rect.top + SPOT_PADDING + TOOLTIP_GAP,
+        top: Math.max(16, rect.top - SPOT_PADDING - TOOLTIP_GAP - TOOLTIP_EST_HEIGHT),
         left: clampedLeft,
       };
+    }
     case "right":
       return {
-        top: Math.max(16, rect.top + rect.height / 2 - 65),
-        left: rect.right + SPOT_PADDING + TOOLTIP_GAP,
+        top: Math.max(16, Math.min(rect.top + rect.height / 2 - 65, vh - TOOLTIP_EST_HEIGHT - 16)),
+        left: Math.min(
+          rect.right + SPOT_PADDING + TOOLTIP_GAP,
+          window.innerWidth - TOOLTIP_WIDTH - 16,
+        ),
       };
+    case "left": {
+      const rawLeft = rect.left - TOOLTIP_WIDTH - SPOT_PADDING - TOOLTIP_GAP;
+      return {
+        top: Math.max(16, Math.min(rect.top + rect.height / 2 - 65, vh - TOOLTIP_EST_HEIGHT - 16)),
+        left: Math.max(16, rawLeft),
+      };
+    }
   }
 }
 
 // ─── SpotlightTour ─────────────────────────────────────────────────────────────
 
-export default function SpotlightTour() {
-  const markSpotlightSeen = useOnboardingStore((s) => s.markSpotlightSeen);
+export default function SpotlightTour({ tourKey, steps }: Props) {
+  const hasSeenOnboarding = useOnboardingStore((s) => s.hasSeenOnboarding);
+  const seenTours = useOnboardingStore((s) => s.seenTours);
+  const markTourSeen = useOnboardingStore((s) => s.markTourSeen);
+
+  const hasSeen = !hasSeenOnboarding || (seenTours[tourKey] ?? false);
+
   const [stepIdx, setStepIdx] = useState(0);
   const [rect, setRect] = useState<DOMRect | null>(null);
   const [tooltipVisible, setTooltipVisible] = useState(false);
 
-  const step = STEPS[stepIdx];
-  const isFinal = stepIdx === STEPS.length - 1;
+  const step = steps[stepIdx];
+  const isFinal = stepIdx === steps.length - 1;
 
   useEffect(() => {
+    if (hasSeen || !step) return;
     setTooltipVisible(false);
 
-    const el = document.querySelector<HTMLElement>(`[data-tour="${step.target}"]`);
-    if (!el) {
-      // 요소를 찾지 못하면 다음 스텝으로
-      if (stepIdx < STEPS.length - 1) setStepIdx((s) => s + 1);
-      else markSpotlightSeen();
-      return;
-    }
+    const ids: ReturnType<typeof window.setTimeout>[] = [];
 
-    el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    ids.push(
+      window.setTimeout(() => {
+        const el = document.querySelector<HTMLElement>(`[data-tour="${step.target}"]`);
+        if (!el) {
+          if (stepIdx < steps.length - 1) setStepIdx((s) => s + 1);
+          else markTourSeen(tourKey);
+          return;
+        }
 
-    const id = window.setTimeout(() => {
-      const updated = document.querySelector<HTMLElement>(`[data-tour="${step.target}"]`);
-      if (updated) {
-        setRect(updated.getBoundingClientRect());
-        setTooltipVisible(true);
-      }
-    }, 350);
+        el.scrollIntoView({ behavior: "smooth", block: "nearest" });
 
-    return () => window.clearTimeout(id);
-  }, [stepIdx, step.target, markSpotlightSeen]);
+        ids.push(
+          window.setTimeout(() => {
+            const updated = document.querySelector<HTMLElement>(
+              `[data-tour="${step.target}"]`,
+            );
+            if (updated) {
+              setRect(updated.getBoundingClientRect());
+              setTooltipVisible(true);
+            }
+          }, 350),
+        );
+      }, 0),
+    );
 
-  // 리사이즈 시 rect 재계산
+    return () => ids.forEach((id) => window.clearTimeout(id));
+  }, [stepIdx, step?.target, hasSeen, tourKey, markTourSeen, steps.length]);
+
   useEffect(() => {
-    const onResize = () => {
+    if (hasSeen || !step) return;
+    const updateRect = () => {
       const el = document.querySelector<HTMLElement>(`[data-tour="${step.target}"]`);
       if (el) setRect(el.getBoundingClientRect());
     };
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, [step.target]);
+    // 스크롤·리사이즈 시 하이라이트가 요소를 따라가도록 실시간 업데이트
+    window.addEventListener("resize", updateRect);
+    window.addEventListener("scroll", updateRect, true); // capture: true로 내부 스크롤도 감지
+    return () => {
+      window.removeEventListener("resize", updateRect);
+      window.removeEventListener("scroll", updateRect, true);
+    };
+  }, [step?.target, hasSeen]);
 
   const handleNext = () => {
     if (isFinal) {
-      markSpotlightSeen();
+      markTourSeen(tourKey);
     } else {
       setTooltipVisible(false);
       setTimeout(() => setStepIdx((s) => s + 1), 200);
     }
   };
 
-  if (!rect) return null;
+  if (hasSeen || !rect || !step) return null;
 
+  const dr = getDisplayRect(rect);
   const sp = SPOT_PADDING;
 
   return (
     <>
-      {/* ── 어두운 오버레이 + 하이라이트 홀 (SVG 마스크) ── */}
+      {/* ── 오버레이 + 하이라이트 홀 ── */}
       <div className="fixed inset-0" style={{ zIndex: 51, pointerEvents: "none" }}>
         <svg
           width="100%"
@@ -145,10 +197,10 @@ export default function SpotlightTour() {
             <mask id="spotlight-mask">
               <rect width="100%" height="100%" fill="white" />
               <rect
-                x={rect.x - sp}
-                y={rect.y - sp}
-                width={rect.width + sp * 2}
-                height={rect.height + sp * 2}
+                x={dr.x - sp}
+                y={dr.y - sp}
+                width={dr.width + sp * 2}
+                height={dr.height + sp * 2}
                 rx="12"
                 fill="black"
               />
@@ -161,15 +213,13 @@ export default function SpotlightTour() {
             mask="url(#spotlight-mask)"
           />
         </svg>
-
-        {/* 파란 테두리 링 */}
         <div
           className="absolute rounded-xl"
           style={{
-            top: rect.y - sp,
-            left: rect.x - sp,
-            width: rect.width + sp * 2,
-            height: rect.height + sp * 2,
+            top: dr.y - sp,
+            left: dr.x - sp,
+            width: dr.width + sp * 2,
+            height: dr.height + sp * 2,
             border: "2px solid #0046FF",
             boxShadow: "0 0 0 3px rgba(0,70,255,0.15)",
             transition: "all 0.3s ease",
@@ -181,7 +231,7 @@ export default function SpotlightTour() {
       <div
         className="fixed w-[280px] z-[52]"
         style={{
-          ...getTooltipPos(rect, step.placement),
+          ...getTooltipPos(dr, step.placement),
           opacity: tooltipVisible ? 1 : 0,
           transform: tooltipVisible ? "translateY(0)" : "translateY(6px)",
           transition: "opacity 0.2s ease, transform 0.2s ease",
@@ -189,9 +239,9 @@ export default function SpotlightTour() {
         }}
       >
         <div className="bg-white rounded-2xl shadow-2xl overflow-hidden">
-          {/* 상단 진행 바 */}
+          {/* 진행 바 */}
           <div className="flex h-1">
-            {STEPS.map((_, i) => (
+            {steps.map((_, i) => (
               <div
                 key={i}
                 className="flex-1 transition-colors duration-300"
@@ -201,31 +251,47 @@ export default function SpotlightTour() {
           </div>
 
           <div className="p-4">
-            {/* 헤더 */}
             <div className="flex items-center justify-between mb-3">
               <span className="text-xs font-semibold text-[#0046FF] bg-blue-50 px-2.5 py-0.5 rounded-full">
-                {stepIdx + 1} / {STEPS.length}
+                {stepIdx + 1} / {steps.length}
               </span>
               <button
                 className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                onClick={markSpotlightSeen}
+                onClick={() => markTourSeen(tourKey)}
               >
                 건너뛰기
               </button>
             </div>
 
-            {/* 내용 */}
-            <h3 className="text-[15px] font-bold text-gray-900 mb-1.5">{step.title}</h3>
-            <p className="text-[13px] text-gray-500 leading-relaxed mb-4">
+            <h3 className="text-[15px] font-bold text-gray-900 mb-1.5">
+              {step.title}
+            </h3>
+            <p className="text-[13px] text-gray-500 leading-relaxed mb-2">
               {step.description}
             </p>
+            {step.items && (
+              <ul className="mb-2 flex flex-col gap-1.5">
+                {step.items.map((item, i) => (
+                  <li key={i} className="flex items-center gap-2 text-[13px] text-gray-700">
+                    <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-[#0046FF] inline-block" />
+                    <span className="leading-snug">
+                      {typeof item === "string" ? item : (
+                        <>
+                          <span className="font-semibold" style={{ color: item.labelColor }}>{item.label}</span>
+                          {" "}{item.text}
+                        </>
+                      )}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
 
-            {/* 버튼 */}
             <button
               className="w-full py-2.5 bg-[#0046FF] text-white text-sm font-medium rounded-[8px] hover:bg-[#0038CC] transition-colors"
               onClick={handleNext}
             >
-              {isFinal ? "둘러보기 완료" : "다음"}
+              {isFinal ? "확인" : "다음"}
             </button>
           </div>
         </div>

--- a/src/components/onboarding/SpotlightTour.tsx
+++ b/src/components/onboarding/SpotlightTour.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useState } from "react";
+import { useOnboardingStore } from "@/store/onboardingStore";
+
+// ─── 상수 ──────────────────────────────────────────────────────────────────────
+
+const SPOT_PADDING = 10; // 하이라이트 요소 주변 여백
+const TOOLTIP_GAP = 16;  // 스팟라이트 ~ 툴팁 사이 간격
+const TOOLTIP_WIDTH = 280;
+
+// ─── 스텝 정의 ─────────────────────────────────────────────────────────────────
+
+type Placement = "bottom" | "top" | "right";
+
+type Step = {
+  target: string;
+  title: string;
+  description: string;
+  placement: Placement;
+};
+
+const STEPS: Step[] = [
+  {
+    target: "market-indices",
+    title: "시장 지수",
+    description: "코스피·코스닥·환율이 오늘 얼마나 움직였는지 실시간으로 보여줘요.",
+    placement: "bottom",
+  },
+  {
+    target: "portfolio",
+    title: "내 자산",
+    description: "가상 자금으로 얼마나 수익을 냈는지 한 눈에 확인할 수 있어요.",
+    placement: "bottom",
+  },
+  {
+    target: "holdings",
+    title: "보유 종목",
+    description: "내가 매수한 주식들의 현황이 여기에 표시돼요.",
+    placement: "top",
+  },
+  {
+    target: "nav-invest",
+    title: "모의투자",
+    description: "원하는 주식을 검색하고 매수·매도할 수 있어요. 지금 바로 눌러봐요!",
+    placement: "right",
+  },
+];
+
+// ─── 툴팁 위치 계산 ────────────────────────────────────────────────────────────
+
+function getTooltipPos(rect: DOMRect, placement: Placement): React.CSSProperties {
+  const clampedLeft = Math.min(
+    Math.max(16, rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2),
+    window.innerWidth - TOOLTIP_WIDTH - 16,
+  );
+
+  switch (placement) {
+    case "bottom":
+      return {
+        top: rect.bottom + SPOT_PADDING + TOOLTIP_GAP,
+        left: clampedLeft,
+      };
+    case "top":
+      // bottom 기준: 뷰포트 하단 → rect.top 위로
+      return {
+        bottom: window.innerHeight - rect.top + SPOT_PADDING + TOOLTIP_GAP,
+        left: clampedLeft,
+      };
+    case "right":
+      return {
+        top: Math.max(16, rect.top + rect.height / 2 - 65),
+        left: rect.right + SPOT_PADDING + TOOLTIP_GAP,
+      };
+  }
+}
+
+// ─── SpotlightTour ─────────────────────────────────────────────────────────────
+
+export default function SpotlightTour() {
+  const markSpotlightSeen = useOnboardingStore((s) => s.markSpotlightSeen);
+  const [stepIdx, setStepIdx] = useState(0);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+
+  const step = STEPS[stepIdx];
+  const isFinal = stepIdx === STEPS.length - 1;
+
+  useEffect(() => {
+    setTooltipVisible(false);
+
+    const el = document.querySelector<HTMLElement>(`[data-tour="${step.target}"]`);
+    if (!el) {
+      // 요소를 찾지 못하면 다음 스텝으로
+      if (stepIdx < STEPS.length - 1) setStepIdx((s) => s + 1);
+      else markSpotlightSeen();
+      return;
+    }
+
+    el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+
+    const id = window.setTimeout(() => {
+      const updated = document.querySelector<HTMLElement>(`[data-tour="${step.target}"]`);
+      if (updated) {
+        setRect(updated.getBoundingClientRect());
+        setTooltipVisible(true);
+      }
+    }, 350);
+
+    return () => window.clearTimeout(id);
+  }, [stepIdx, step.target, markSpotlightSeen]);
+
+  // 리사이즈 시 rect 재계산
+  useEffect(() => {
+    const onResize = () => {
+      const el = document.querySelector<HTMLElement>(`[data-tour="${step.target}"]`);
+      if (el) setRect(el.getBoundingClientRect());
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [step.target]);
+
+  const handleNext = () => {
+    if (isFinal) {
+      markSpotlightSeen();
+    } else {
+      setTooltipVisible(false);
+      setTimeout(() => setStepIdx((s) => s + 1), 200);
+    }
+  };
+
+  if (!rect) return null;
+
+  const sp = SPOT_PADDING;
+
+  return (
+    <>
+      {/* ── 어두운 오버레이 + 하이라이트 홀 (SVG 마스크) ── */}
+      <div className="fixed inset-0" style={{ zIndex: 51, pointerEvents: "none" }}>
+        <svg
+          width="100%"
+          height="100%"
+          className="absolute inset-0"
+          style={{ display: "block" }}
+        >
+          <defs>
+            <mask id="spotlight-mask">
+              <rect width="100%" height="100%" fill="white" />
+              <rect
+                x={rect.x - sp}
+                y={rect.y - sp}
+                width={rect.width + sp * 2}
+                height={rect.height + sp * 2}
+                rx="12"
+                fill="black"
+              />
+            </mask>
+          </defs>
+          <rect
+            width="100%"
+            height="100%"
+            fill="rgba(0,0,0,0.65)"
+            mask="url(#spotlight-mask)"
+          />
+        </svg>
+
+        {/* 파란 테두리 링 */}
+        <div
+          className="absolute rounded-xl"
+          style={{
+            top: rect.y - sp,
+            left: rect.x - sp,
+            width: rect.width + sp * 2,
+            height: rect.height + sp * 2,
+            border: "2px solid #0046FF",
+            boxShadow: "0 0 0 3px rgba(0,70,255,0.15)",
+            transition: "all 0.3s ease",
+          }}
+        />
+      </div>
+
+      {/* ── 툴팁 ── */}
+      <div
+        className="fixed w-[280px] z-[52]"
+        style={{
+          ...getTooltipPos(rect, step.placement),
+          opacity: tooltipVisible ? 1 : 0,
+          transform: tooltipVisible ? "translateY(0)" : "translateY(6px)",
+          transition: "opacity 0.2s ease, transform 0.2s ease",
+          pointerEvents: tooltipVisible ? "auto" : "none",
+        }}
+      >
+        <div className="bg-white rounded-2xl shadow-2xl overflow-hidden">
+          {/* 상단 진행 바 */}
+          <div className="flex h-1">
+            {STEPS.map((_, i) => (
+              <div
+                key={i}
+                className="flex-1 transition-colors duration-300"
+                style={{ backgroundColor: i <= stepIdx ? "#0046FF" : "#E5E7EB" }}
+              />
+            ))}
+          </div>
+
+          <div className="p-4">
+            {/* 헤더 */}
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-xs font-semibold text-[#0046FF] bg-blue-50 px-2.5 py-0.5 rounded-full">
+                {stepIdx + 1} / {STEPS.length}
+              </span>
+              <button
+                className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                onClick={markSpotlightSeen}
+              >
+                건너뛰기
+              </button>
+            </div>
+
+            {/* 내용 */}
+            <h3 className="text-[15px] font-bold text-gray-900 mb-1.5">{step.title}</h3>
+            <p className="text-[13px] text-gray-500 leading-relaxed mb-4">
+              {step.description}
+            </p>
+
+            {/* 버튼 */}
+            <button
+              className="w-full py-2.5 bg-[#0046FF] text-white text-sm font-medium rounded-[8px] hover:bg-[#0038CC] transition-colors"
+              onClick={handleNext}
+            >
+              {isFinal ? "둘러보기 완료" : "다음"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/stocks/TradeOrderModal.tsx
+++ b/src/components/stocks/TradeOrderModal.tsx
@@ -1,6 +1,39 @@
 import { useState } from "react";
 import { X, AlertCircle } from "lucide-react";
 import Button from "@/components/ui/Button";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const TRADE_ORDER_TOUR: TourStep[] = [
+  {
+    target: "trade-order-available",
+    title: "💰 주문 가능금액",
+    description: "현재 내 예수금(투자에 쓸 수 있는 현금)이에요. 이 금액 안에서만 매수할 수 있어요.",
+    placement: "bottom",
+  },
+  {
+    target: "trade-order-type",
+    title: "📌 시장가 vs 지정가",
+    description: "주문 방식을 선택해요.",
+    items: [
+      "시장가 — 지금 바로 현재 가격으로 체결돼요",
+      "지정가 — 내가 원하는 가격을 직접 입력해요. 그 가격이 될 때 체결돼요",
+    ],
+    placement: "bottom",
+  },
+  {
+    target: "trade-order-quantity",
+    title: "🔢 수량 입력",
+    description: "몇 주를 살지 입력해요. 아래 최대 수량을 넘을 수 없어요.",
+    placement: "bottom",
+  },
+  {
+    target: "trade-order-diary",
+    title: "✍️ 매매일지 (필수)",
+    description: "이 주식을 사는 이유를 꼭 기록해야 주문할 수 있어요. 나중에 내 투자 패턴을 분석하는 데 도움이 돼요.",
+    placement: "top",
+  },
+];
 
 type OrderType = "MARKET" | "LIMIT";
 
@@ -74,7 +107,7 @@ export default function TradeOrderModal({
         </div>
 
         {/* 주문 가능금액 */}
-        <div className={`rounded-xl px-3 py-2 mb-3 ${accent.bgLight}`}>
+        <div className={`rounded-xl px-3 py-2 mb-3 ${accent.bgLight}`} data-tour="trade-order-available">
           <div className="flex justify-between items-center">
             <span className="text-[12px] font-semibold text-gray-500">주문 가능금액</span>
             <span className={`text-[12px] font-bold ${accent.text}`}>
@@ -84,7 +117,7 @@ export default function TradeOrderModal({
         </div>
 
         {/* 시장가 / 지정가 */}
-        <div className="flex bg-gray-100 rounded-xl p-1 mb-3">
+        <div className="flex bg-gray-100 rounded-xl p-1 mb-3" data-tour="trade-order-type">
           {(["MARKET", "LIMIT"] as OrderType[]).map((t) => (
             <button
               key={t}
@@ -119,7 +152,7 @@ export default function TradeOrderModal({
         </div>
 
         {/* 수량 */}
-        <div className="mb-3">
+        <div className="mb-3" data-tour="trade-order-quantity">
           <label className="text-[12px] font-semibold text-gray-500 mb-1 block">
             수량 (주)
           </label>
@@ -147,7 +180,7 @@ export default function TradeOrderModal({
         </div>
 
         {/* 매매일지 */}
-        <div className="mb-3">
+        <div className="mb-3" data-tour="trade-order-diary">
           <div className="flex items-center justify-between mb-1">
             <label className="text-[13px] font-semibold text-gray-700">
               매매일지 <span className="text-red-400">*</span>
@@ -171,6 +204,8 @@ export default function TradeOrderModal({
             </p>
           )}
         </div>
+
+        <SpotlightTour tourKey="trade-order" steps={TRADE_ORDER_TOUR} />
 
         {/* 버튼 */}
         <div className="flex gap-2">

--- a/src/index.css
+++ b/src/index.css
@@ -42,3 +42,13 @@
     text-wrap: balance;
   }
 }
+
+/* 6. 커스텀 애니메이션 */
+@keyframes float {
+  0%, 100% { transform: translateY(0px); }
+  50% { transform: translateY(-6px); }
+}
+
+.animate-float {
+  animation: float 2.4s ease-in-out infinite;
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,39 @@
 import { useNavigate } from "react-router-dom";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const HOME_TOUR: TourStep[] = [
+  {
+    target: "market-indices",
+    title: "📈 오늘 주식시장은?",
+    description: "코스피·코스닥·환율을 실시간으로 보여줘요. 빨강(▲)이면 오름, 파랑(▼)이면 내림이에요.",
+    placement: "bottom",
+  },
+  {
+    target: "portfolio",
+    title: "💰 내 자산 현황",
+    description: "가상 1,000만원으로 시작한 내 돈이 얼마가 됐는지 보여줘요. 예수금은 아직 투자 안 한 현금이에요.",
+    placement: "bottom",
+  },
+  {
+    target: "holdings",
+    title: "📦 내가 산 주식들",
+    description: "지금 가지고 있는 주식 목록이에요. 각 종목이 얼마나 올랐는지(수익률) 바로 확인할 수 있어요.",
+    placement: "top",
+  },
+  {
+    target: "top-investors",
+    title: "🏆 TOP 투자자",
+    description: "수익을 가장 많이 낸 투자자 순위예요. 클릭하면 그 사람이 어떤 주식을 샀는지 볼 수 있어요!",
+    placement: "top",
+  },
+  {
+    target: "popular-stocks",
+    title: "🔥 인기 종목",
+    description: "지금 가장 많이 거래되고 있는 주식이에요. 클릭하면 해당 종목의 차트와 매수·매도 화면으로 바로 이동해요.",
+    placement: "top",
+  },
+];
 import { Bell, ChevronRight, TrendingUp, TrendingDown } from "lucide-react";
 import Avatar from "@/components/ui/Avatar";
 import { useMarketIndicesQuery } from "@/api/homeApi";
@@ -537,21 +572,24 @@ export default function HomePage() {
         {/* 왼쪽: 포트폴리오 + 보유 종목 */}
         <div className="flex flex-col gap-4" style={{ flex: "0 0 58%" }}>
           <div data-tour="portfolio">
-            <PortfolioCard data={portfolio} loading={false} />
+            <PortfolioCard data={summary} loading={loadingSummary} />
           </div>
           <div data-tour="holdings">
-            <HoldingsTable data={holdings} loading={false} />
+            <HoldingsTable data={holdings} loading={loadingHoldings} />
           </div>
-          <PortfolioCard data={summary} loading={loadingSummary} />
-          <HoldingsTable data={holdings} loading={loadingHoldings} />
         </div>
 
         {/* 오른쪽: TOP 투자자 + 인기 종목 */}
         <div className="flex flex-col gap-4 flex-1 min-w-0">
-          <TopInvestors data={allUsers} loading={loadingUsers} />
-          <PopularStocks data={stocks} loading={loadingStocks} />
+          <div data-tour="top-investors">
+            <TopInvestors data={allUsers} loading={loadingUsers} />
+          </div>
+          <div data-tour="popular-stocks">
+            <PopularStocks data={stocks} loading={loadingStocks} />
+          </div>
         </div>
       </div>
+      <SpotlightTour tourKey="home" steps={HOME_TOUR} />
     </div>
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -286,14 +286,20 @@ export default function HomePage() {
       </div>
 
       {/* 시장 지수 */}
-      <MarketIndicesRow data={marketIndices} loading={loadingMarket} />
+      <div data-tour="market-indices">
+        <MarketIndicesRow data={marketIndices} loading={loadingMarket} />
+      </div>
 
       {/* 메인 콘텐츠 */}
       <div className="flex gap-5 items-start">
         {/* 왼쪽: 포트폴리오 + 보유 종목 */}
         <div className="flex flex-col gap-4" style={{ flex: "0 0 58%" }}>
-          <PortfolioCard data={portfolio} loading={false} />
-          <HoldingsTable data={holdings} loading={false} />
+          <div data-tour="portfolio">
+            <PortfolioCard data={portfolio} loading={false} />
+          </div>
+          <div data-tour="holdings">
+            <HoldingsTable data={holdings} loading={false} />
+          </div>
         </div>
 
         {/* 오른쪽: TOP 투자자 + 인기 종목 */}

--- a/src/pages/account/AccountPage.tsx
+++ b/src/pages/account/AccountPage.tsx
@@ -1,6 +1,23 @@
 import PortfolioChart from "@/components/account/PortfolioChart";
 import HoldingList from "@/components/account/HoldingList";
 import { useAccountSummaryQuery, useHoldingsQuery } from "@/api/accountApi";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const ACCOUNT_TOUR: TourStep[] = [
+  {
+    target: "account-summary",
+    title: "💳 내 계좌 한눈에",
+    description: "내 투자 현황을 나타내는 4가지 지표예요.",
+    items: [
+      "총 자산 — 예수금 + 보유 주식 평가금액",
+      "보유 현금 — 아직 투자하지 않은 내 돈 (예수금)",
+      "보유 종목 — 현재 가지고 있는 주식 수",
+      "수익률 — 원금 대비 얼마나 벌었는지 (%)",
+    ],
+    placement: "bottom",
+  },
+];
 
 function fmt(n: number) {
   if (Math.abs(n) >= 100_000_000) return `${(n / 100_000_000).toFixed(1)}억원`;
@@ -33,7 +50,7 @@ export default function AccountPage() {
         <p className="text-[13px] text-gray-400 mt-0.5">나의 투자 현황을 한눈에 확인하세요</p>
       </div>
 
-      <div className="grid grid-cols-[2fr_1fr_1fr_1fr] gap-4 items-stretch">
+      <div className="grid grid-cols-[2fr_1fr_1fr_1fr] gap-4 items-stretch" data-tour="account-summary">
 
         {/* 보유 총 자산 */}
         <div className="bg-[#0046FF] rounded-2xl px-6 py-5 text-white">
@@ -82,6 +99,7 @@ export default function AccountPage() {
           <HoldingList items={holdings} />
         </div>
       </div>
+      <SpotlightTour tourKey="account" steps={ACCOUNT_TOUR} />
     </div>
   );
 }

--- a/src/pages/mentee/MyMenteePage.tsx
+++ b/src/pages/mentee/MyMenteePage.tsx
@@ -1,6 +1,32 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Users, TrendingUp, Loader2 } from "lucide-react";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const MENTEE_TOUR: TourStep[] = [
+  {
+    target: "mentee-list",
+    title: "👥 나의 멘티 목록",
+    description: "나에게 멘토 신청을 한 투자자들이에요.",
+    items: [
+      "클릭하면 그 멘티의 투자 기록을 볼 수 있어요",
+      "멘티의 수익률도 한눈에 확인할 수 있어요",
+    ],
+    placement: "right",
+  },
+  {
+    target: "mentee-detail",
+    title: "📋 멘티의 투자 기록",
+    description: "선택한 멘티가 어떻게 투자하고 있는지 확인할 수 있어요.",
+    items: [
+      "매매일지 — 멘티가 남긴 메모에 피드백을 줄 수 있어요",
+      "매매내역 — 멘티의 거래 기록",
+      "포트폴리오 — 멘티가 보유한 종목 현황",
+    ],
+    placement: "left",
+  },
+];
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
@@ -198,7 +224,7 @@ export default function MyMenteePage() {
 
       <div className="flex gap-4 flex-1 min-h-0">
         {/* 멘티 목록 (좌측) */}
-        <div className="w-[180px] shrink-0 bg-white rounded-2xl border border-gray-100 flex flex-col overflow-hidden">
+        <div className="w-[180px] shrink-0 bg-white rounded-2xl border border-gray-100 flex flex-col overflow-hidden" data-tour="mentee-list">
           <div className="px-4 py-3 border-b border-gray-100 shrink-0">
             <p className="text-[12px] font-semibold text-gray-400">멘티 목록</p>
           </div>
@@ -215,8 +241,11 @@ export default function MyMenteePage() {
         </div>
 
         {/* 멘티 상세 (우측) */}
-        <MenteeDetail key={selectedId} menteeId={selectedId} />
+        <div className="flex-1 min-h-0 flex flex-col" data-tour="mentee-detail">
+          <MenteeDetail key={selectedId} menteeId={selectedId} />
+        </div>
       </div>
+      <SpotlightTour tourKey="mentee" steps={MENTEE_TOUR} />
     </div>
   );
 }

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -1,6 +1,33 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Users, TrendingUp, Loader2, X } from "lucide-react";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const MENTOR_TOUR: TourStep[] = [
+  {
+    target: "mentor-card",
+    title: "🎓 나의 멘토",
+    description: "멘토로 등록한 투자자의 정보예요.",
+    items: [
+      "멘토의 수익률·수익을 한눈에 볼 수 있어요",
+      "프로필 보기로 더 자세한 정보를 확인해요",
+      "멘토 취소 시 언제든 다시 신청할 수 있어요",
+    ],
+    placement: "bottom",
+  },
+  {
+    target: "mentor-tabs",
+    title: "📖 멘토의 투자 기록",
+    description: "멘토가 어떻게 투자하는지 직접 확인할 수 있어요.",
+    items: [
+      "매매일지 — 멘토가 거래할 때 남긴 메모",
+      "매매내역 — 멘토의 모든 거래 기록",
+      "포트폴리오 — 멘토가 보유한 종목 현황",
+    ],
+    placement: "bottom",
+  },
+];
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
@@ -114,7 +141,7 @@ export default function MyMentorPage() {
       </div>
 
       {/* 멘토 카드 */}
-      <div className="bg-white rounded-2xl border border-gray-100 px-6 py-4 shrink-0">
+      <div className="bg-white rounded-2xl border border-gray-100 px-6 py-4 shrink-0" data-tour="mentor-card">
         <div className="flex items-center gap-4">
           {/* 아바타 + 닉네임 + 통계 */}
           <div className="flex items-center gap-3 flex-1">
@@ -161,7 +188,7 @@ export default function MyMentorPage() {
       </div>
 
       {/* 탭 + 콘텐츠 */}
-      <div className="flex-1 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
+      <div className="flex-1 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col" data-tour="mentor-tabs">
         <UnderlineTabBar
           tabs={[...TABS]}
           activeId={activeTab}
@@ -191,6 +218,7 @@ export default function MyMentorPage() {
           )}
         </div>
       </div>
+      <SpotlightTour tourKey="mentor" steps={MENTOR_TOUR} />
     </div>
   );
 }

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -1,5 +1,31 @@
 import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const PROFILE_TOUR: TourStep[] = [
+  {
+    target: "profile-card",
+    title: "👤 내 프로필",
+    description: "나의 투자 활동 기록이 쌓이는 공간이에요.",
+    items: [
+      "팔로워·팔로잉 — 서로 구독한 투자자 수",
+      "수익률 — 지금까지의 내 총 투자 성과",
+    ],
+    placement: "right",
+  },
+  {
+    target: "profile-tabs",
+    title: "📂 내 기록 보기",
+    description: "투자 관련 기록을 탭별로 확인할 수 있어요.",
+    items: [
+      "매매일지 — 거래할 때 남긴 메모 모음",
+      "매매내역 — 지금까지의 모든 거래 기록",
+      "포트폴리오 — 보유 종목 비중 파이 차트",
+    ],
+    placement: "left",
+  },
+];
 import { useUser } from "@/store/authStore";
 import { useAuthStore } from "@/store/authStore";
 import { authApi } from "@/api/authApi";
@@ -90,7 +116,7 @@ export default function ProfilePage() {
 
       <div className="flex gap-5 flex-1 min-h-0">
         {/* 왼쪽: 프로필 카드 */}
-        <div className="w-64 shrink-0 overflow-y-auto h-full flex flex-col">
+        <div className="w-64 shrink-0 overflow-y-auto h-full flex flex-col" data-tour="profile-card">
           <ProfileCard
             nickname={myProfile?.nickname ?? user.nickname}
             profileImageUrl={myProfile?.imageUrl}
@@ -110,7 +136,7 @@ export default function ProfilePage() {
         </div>
 
         {/* 오른쪽: 탭 + 콘텐츠 */}
-        <div className="flex-1 min-w-0 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col">
+        <div className="flex-1 min-w-0 min-h-0 bg-white rounded-2xl border border-gray-100 overflow-hidden flex flex-col" data-tour="profile-tabs">
           {/* 탭 바 */}
           <UnderlineTabBar
             tabs={[...TABS]}
@@ -134,6 +160,7 @@ export default function ProfilePage() {
           </div>
         </div>
       </div>
+      <SpotlightTour tourKey="profile" steps={PROFILE_TOUR} />
     </div>
   );
 }

--- a/src/pages/stocks/StockList.tsx
+++ b/src/pages/stocks/StockList.tsx
@@ -1,5 +1,45 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const INVEST_TOUR: TourStep[] = [
+  {
+    target: "invest-market",
+    title: "📈 코스피 · 코스닥이 뭔가요?",
+    description: "주식 시장 전체의 흐름을 숫자 하나로 나타낸 지수예요.",
+    items: [
+      "코스피(KOSPI) — 삼성·현대 같은 대형 우량 기업 지수",
+      "코스닥(KOSDAQ) — 네이버·카카오 같은 중소·기술 기업 지수",
+      "지수가 오르면 시장 전체 분위기가 좋은 날이에요!",
+    ],
+    placement: "bottom",
+  },
+  {
+    target: "stock-columns",
+    title: "🔢 각 숫자가 무슨 뜻이에요?",
+    description: "종목 리스트에서 보이는 숫자들이에요.",
+    items: [
+      "현재가 — 지금 이 순간 거래되는 가격",
+      "등락률 — 어제보다 얼마나 올랐는지 (%)",
+      "거래량 — 오늘 사고판 주식 수",
+      "시가총액 — 회사 주식을 전부 사면 드는 돈 (회사 규모)",
+    ],
+    placement: "bottom",
+  },
+  {
+    target: "stock-search",
+    title: "🔍 원하는 종목 찾기",
+    description: "회사 이름으로 검색하거나 거래량·등락률 순으로 정렬해서 마음에 드는 종목을 찾아봐요.",
+    placement: "bottom",
+  },
+  {
+    target: "stock-table",
+    title: "📋 종목을 클릭해봐요!",
+    description: "현재가·등락률이 실시간으로 바뀌어요. 종목을 클릭하면 차트 보기와 매수·매도 화면으로 이동해요!",
+    placement: "bottom",
+  },
+];
 import { Search, TrendingUp, TrendingDown } from "lucide-react";
 import Avatar from "@/components/ui/Avatar";
 import { useStockStore } from "@/store/stockStore";
@@ -224,10 +264,12 @@ export default function StockList() {
       </div>
 
       {/* 시장 지수 */}
-      <MarketPanel data={marketIndices} loading={loadingMarket} />
+      <div data-tour="invest-market">
+        <MarketPanel data={marketIndices} loading={loadingMarket} />
+      </div>
 
       {/* 검색 + 정렬 */}
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3" data-tour="stock-search">
         <div className="relative flex-1 max-w-xs">
           <Search
             size={15}
@@ -275,8 +317,10 @@ export default function StockList() {
         ))}
       </div>
 
+      <SpotlightTour tourKey="invest" steps={INVEST_TOUR} />
+
       {/* 종목 테이블 */}
-      <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
+      <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden" data-tour="stock-table">
         <table className="w-full table-fixed">
           <colgroup>
             <col className="w-[60px]" />
@@ -287,7 +331,7 @@ export default function StockList() {
             <col className="w-[150px]" />
             <col />
           </colgroup>
-          <thead>
+          <thead data-tour="stock-columns">
             <tr className="bg-gray-50 border-b border-gray-100">
               <th className="text-center px-5 py-3 text-[12px] text-gray-400 font-medium whitespace-nowrap">
                 순위

--- a/src/pages/stocks/[stockId]/StockDetailPage.tsx
+++ b/src/pages/stocks/[stockId]/StockDetailPage.tsx
@@ -1,5 +1,64 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const STOCK_DETAIL_TOUR: TourStep[] = [
+  {
+    target: "stock-chart",
+    title: "📊 주가 차트",
+    description: "주가가 시간에 따라 어떻게 변했는지 보여줘요.",
+    items: [
+      "빨간 캔들 — 어제보다 오른 날",
+      "파란 캔들 — 어제보다 내린 날",
+      "오른쪽으로 갈수록 최근 데이터예요",
+    ],
+    placement: "bottom",
+  },
+  {
+    target: "stock-info",
+    title: "📋 오늘의 주가 정보",
+    description: "오늘 하루 동안의 주요 가격이에요.",
+    items: [
+      "시가 — 오늘 장이 열릴 때 첫 거래 가격",
+      "고가 — 오늘 중 가장 높았던 가격",
+      "저가 — 오늘 중 가장 낮았던 가격",
+      "전일종가 — 어제 마감 가격",
+    ],
+    placement: "bottom",
+  },
+  {
+    target: "stock-holding",
+    title: "💳 보유현황 & 매수·매도",
+    description: "내 주식 현황과 주문 버튼이에요.",
+    items: [
+      "매수 — 주식 사기 (예수금이 줄어요)",
+      "매도 — 주식 팔기 (예수금이 늘어요)",
+      "예수금 범위 안에서만 매수할 수 있어요",
+    ],
+    placement: "left",
+  },
+  {
+    target: "stock-orderbook",
+    title: "📚 호가창",
+    description: "사려는 사람과 팔려는 사람의 희망 가격이에요.",
+    items: [
+      {
+        label: "매도호가",
+        labelColor: "#EF4444",
+        text: "— 팔고 싶은 사람들의 희망 가격 (빨간색)",
+      },
+      {
+        label: "매수호가",
+        labelColor: "#3B82F6",
+        text: "— 사고 싶은 사람들의 희망 가격 (파란색)",
+      },
+      "옆 숫자(잔량) — 그 가격에 대기 중인 주문 수량이에요. 숫자가 클수록 그 가격에 사람이 많아요",
+      "호가와 내 주문가격이 맞을 때 주문이 체결돼요",
+    ],
+    placement: "left",
+  },
+];
 import { Loader2 } from "lucide-react";
 import { Client } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
@@ -13,7 +72,11 @@ import {
   stockQueryKeys,
 } from "@/api/stockApi";
 import { useBuyOrderMutation, useSellOrderMutation } from "@/api/tradeApi";
-import type { StockQuote, StockItemMessage, OrderBookData } from "@/api/stockApi";
+import type {
+  StockQuote,
+  StockItemMessage,
+  OrderBookData,
+} from "@/api/stockApi";
 
 import { useStockStore } from "@/store/stockStore";
 import StockDetailHeader from "@/components/stocks/StockDetailHeader";
@@ -157,79 +220,95 @@ export default function StockDetailPage() {
 
   return (
     <>
-    <div className="flex flex-col p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
-      <StockDetailHeader stock={headerStock} />
+      <div className="flex flex-col p-6 gap-5 overflow-auto bg-gray-50 min-h-screen">
+        <StockDetailHeader stock={headerStock} />
 
-      <div className="flex gap-5 items-start">
-        {/* 왼쪽 */}
-        <div className="flex flex-col gap-5 flex-1 min-w-0">
-          <StockChart stockCode={stockCode} />
+        <div className="flex gap-5 items-start">
+          {/* 왼쪽 */}
+          <div className="flex flex-col gap-5 flex-1 min-w-0">
+            <div data-tour="stock-chart">
+              <StockChart stockCode={stockCode} />
+            </div>
 
-          <StockInfoGrid quote={quote} />
+            <div data-tour="stock-info">
+              <StockInfoGrid quote={quote} />
+            </div>
 
-          <TradeHistory
-            tickerCode={stockCode}
-            orders={tradeHistory?.orders ?? []}
-          />
-        </div>
+            <TradeHistory
+              tickerCode={stockCode}
+              orders={tradeHistory?.orders ?? []}
+            />
+          </div>
 
-        {/* 오른쪽 */}
-        <div className="w-60 shrink-0 flex flex-col gap-4">
-          <HoldingStatus
-            holding={holding}
-            cash={cash}
-            onBuy={() => setOrderSide("buy")}
-            onSell={() => setOrderSide("sell")}
-          />
-          {orderBook && <OrderBook orderBook={orderBook} />}
+          {/* 오른쪽 */}
+          <div className="w-60 shrink-0 flex flex-col gap-4">
+            <div data-tour="stock-holding">
+              <HoldingStatus
+                holding={holding}
+                cash={cash}
+                onBuy={() => setOrderSide("buy")}
+                onSell={() => setOrderSide("sell")}
+              />
+            </div>
+            {orderBook && (
+              <div data-tour="stock-orderbook">
+                <OrderBook orderBook={orderBook} />
+              </div>
+            )}
+          </div>
         </div>
       </div>
-    </div>
 
-    {orderSide && (
-      <TradeOrderModal
-        side={orderSide}
-        stockName={quote.stockName}
-        currentPrice={quote.currentPrice}
-        cash={cash ?? 0}
-        holdingQuantity={holding?.holdingQuantity ?? 0}
-        onClose={() => setOrderSide(null)}
-        onConfirm={(params) => {
-          setPendingOrder({ ...params, side: orderSide! });
-          setOrderSide(null);
-        }}
-      />
-    )}
+      {orderSide && (
+        <TradeOrderModal
+          side={orderSide}
+          stockName={quote.stockName}
+          currentPrice={quote.currentPrice}
+          cash={cash ?? 0}
+          holdingQuantity={holding?.holdingQuantity ?? 0}
+          onClose={() => setOrderSide(null)}
+          onConfirm={(params) => {
+            setPendingOrder({ ...params, side: orderSide! });
+            setOrderSide(null);
+          }}
+        />
+      )}
 
-    {pendingOrder && (
-      <TradeConfirmModal
-        side={pendingOrder.side}
-        stockName={quote?.stockName ?? ""}
-        orderType={pendingOrder.orderType}
-        price={pendingOrder.price}
-        quantity={pendingOrder.quantity}
-        totalAmount={pendingOrder.price * pendingOrder.quantity}
-        onClose={() => setPendingOrder(null)}
-        onConfirm={() => {
-          if (!pendingOrder) return;
-          const body = {
-            ticker: stockCode,
-            orderType: pendingOrder.orderType,
-            price: pendingOrder.price,
-            quantity: pendingOrder.quantity,
-            diary: pendingOrder.diary,
-          };
-          const mutation = pendingOrder.side === "buy" ? buyMutation : sellMutation;
-          mutation.mutate(body, {
-            onSuccess: () => {
-              queryClient.invalidateQueries({ queryKey: stockQueryKeys.holding(stockCode) });
-              queryClient.invalidateQueries({ queryKey: stockQueryKeys.cash });
-              setPendingOrder(null);
-            },
-          });
-        }}
-      />
-    )}
+      {pendingOrder && (
+        <TradeConfirmModal
+          side={pendingOrder.side}
+          stockName={quote?.stockName ?? ""}
+          orderType={pendingOrder.orderType}
+          price={pendingOrder.price}
+          quantity={pendingOrder.quantity}
+          totalAmount={pendingOrder.price * pendingOrder.quantity}
+          onClose={() => setPendingOrder(null)}
+          onConfirm={() => {
+            if (!pendingOrder) return;
+            const body = {
+              ticker: stockCode,
+              orderType: pendingOrder.orderType,
+              price: pendingOrder.price,
+              quantity: pendingOrder.quantity,
+              diary: pendingOrder.diary,
+            };
+            const mutation =
+              pendingOrder.side === "buy" ? buyMutation : sellMutation;
+            mutation.mutate(body, {
+              onSuccess: () => {
+                queryClient.invalidateQueries({
+                  queryKey: stockQueryKeys.holding(stockCode),
+                });
+                queryClient.invalidateQueries({
+                  queryKey: stockQueryKeys.cash,
+                });
+                setPendingOrder(null);
+              },
+            });
+          }}
+        />
+      )}
+      <SpotlightTour tourKey="stock-detail" steps={STOCK_DETAIL_TOUR} />
     </>
   );
 }

--- a/src/pages/trade-diaries/TradeDiaryPage.tsx
+++ b/src/pages/trade-diaries/TradeDiaryPage.tsx
@@ -3,6 +3,17 @@ import { Search } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { MyDiariesItem } from "@/api/tradeDiaryApi";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const DIARY_TOUR: TourStep[] = [
+  {
+    target: "diary-list",
+    title: "✍️ 나만의 투자 기록",
+    description: "매수·매도할 때 남긴 메모가 여기에 쌓여요. 왜 그 주식을 샀는지 기록해두면 나중에 내 투자 패턴을 볼 수 있어요.",
+    placement: "bottom",
+  },
+];
 import Badge from "@/components/ui/Badge";
 
 function MyDiariesRow({
@@ -113,8 +124,10 @@ export default function TradeDiaryPage() {
         </div>
       </div>
 
+      <SpotlightTour tourKey="diary" steps={DIARY_TOUR} />
+
       {/* 매매일지 리스트 (스크롤) */}
-      <div className="flex-1 overflow-y-auto px-6 pb-6">
+      <div className="flex-1 overflow-y-auto px-6 pb-6" data-tour="diary-list">
         <div className="bg-white rounded-2xl border border-gray-100 overflow-y-scroll h-full">
           {filtered.length > 0 ? (
             filtered.map((item) => (

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -1,5 +1,32 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import SpotlightTour from "@/components/onboarding/SpotlightTour";
+import type { TourStep } from "@/components/onboarding/SpotlightTour";
+
+const USERS_TOUR: TourStep[] = [
+  {
+    target: "users-podium",
+    title: "🥇 수익률 TOP 3",
+    description: "지금 가장 수익을 많이 낸 투자자 3명이에요.",
+    items: [
+      "클릭하면 그 사람의 포트폴리오를 볼 수 있어요",
+      "어떤 주식을 얼마나 보유하고 있는지 확인 가능해요",
+    ],
+    placement: "bottom",
+  },
+  {
+    target: "users-follow",
+    title: "➕ 팔로우",
+    description: "관심 있는 투자자를 팔로우하면 홈 화면 TOP 투자자에서 그 사람의 수익률을 바로 확인할 수 있어요.",
+    placement: "left",
+  },
+  {
+    target: "users-mentor",
+    title: "🎓 멘토신청",
+    description: "멘토로 등록하면 그 사람의 매매일지와 포트폴리오를 공유받을 수 있어요. 1명만 멘토로 설정할 수 있어요.",
+    placement: "left",
+  },
+];
 import { Search } from "lucide-react";
 import { useQueries } from "@tanstack/react-query";
 import Avatar from "@/components/ui/Avatar";
@@ -205,6 +232,7 @@ function UserRow({
   onFollowToggle,
   onMentoringRequest,
   onMentoringCancel,
+  isFirstNonMe,
 }: {
   user: UserItem;
   rank: number;
@@ -214,6 +242,7 @@ function UserRow({
   onFollowToggle: (user: UserItem) => void;
   onMentoringRequest: (user: UserItem) => void;
   onMentoringCancel: (user: UserItem) => void;
+  isFirstNonMe?: boolean;
 }) {
   const navigate = useNavigate();
   return (
@@ -252,12 +281,12 @@ function UserRow({
       <ReturnCells summary={summary} isLoading={summaryLoading} />
 
       {/* 팔로우 */}
-      <td className="px-4 py-3.5 text-center">
+      <td className="px-4 py-3.5 text-center" data-tour={isFirstNonMe ? "users-follow" : undefined}>
         <FollowButton user={user} onToggle={onFollowToggle} />
       </td>
 
       {/* 멘토 */}
-      <td className="px-4 py-3.5 text-center">
+      <td className="px-4 py-3.5 text-center" data-tour={isFirstNonMe ? "users-mentor" : undefined}>
         <MentoringButton
           user={user}
           hasAcceptedMentor={hasAcceptedMentor}
@@ -360,7 +389,9 @@ export default function UserListPage() {
       </div>
 
       {/* 포디움 */}
-      {!isLoading && top3.length >= 3 && <Podium users={top3} />}
+      <div data-tour="users-podium">
+        {!isLoading && top3.length >= 3 && <Podium users={top3} />}
+      </div>
 
       {/* 탭 */}
       <div className="flex gap-2">
@@ -379,6 +410,8 @@ export default function UserListPage() {
           </button>
         ))}
       </div>
+
+      <SpotlightTour tourKey="users" steps={USERS_TOUR} />
 
       {/* 랭킹 테이블 */}
       <div className="flex-1 flex flex-col bg-white rounded-2xl border border-gray-100 overflow-hidden min-h-0">
@@ -441,22 +474,26 @@ export default function UserListPage() {
                     <td className="px-5 py-4"><div className="h-7 bg-gray-100 rounded-lg w-18 ml-auto" /></td>
                   </tr>
                 ))
-              : sorted.map((user, i) => {
-                  const s = summaryMap.get(user.userId);
-                  return (
-                    <UserRow
-                      key={user.userId}
-                      user={user}
-                      rank={i + 1}
-                      summary={s?.data}
-                      summaryLoading={s?.isLoading ?? false}
-                      hasAcceptedMentor={hasAcceptedMentor}
-                      onFollowToggle={handleFollowToggle}
-                      onMentoringRequest={handleMentoringRequest}
-                      onMentoringCancel={handleMentoringCancel}
-                    />
-                  );
-                })}
+              : (() => {
+                  const firstNonMeIdx = sorted.findIndex((u) => !u.me);
+                  return sorted.map((user, i) => {
+                    const s = summaryMap.get(user.userId);
+                    return (
+                      <UserRow
+                        key={user.userId}
+                        user={user}
+                        rank={i + 1}
+                        summary={s?.data}
+                        summaryLoading={s?.isLoading ?? false}
+                        hasAcceptedMentor={hasAcceptedMentor}
+                        onFollowToggle={handleFollowToggle}
+                        onMentoringRequest={handleMentoringRequest}
+                        onMentoringCancel={handleMentoringCancel}
+                        isFirstNonMe={i === firstNonMeIdx}
+                      />
+                    );
+                  });
+                })()}
           </tbody>
         </table>
         </div>

--- a/src/store/onboardingStore.ts
+++ b/src/store/onboardingStore.ts
@@ -1,24 +1,61 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 interface OnboardingState {
   hasSeenOnboarding: boolean;
-  hasSeenSpotlight: boolean;
+  seenTours: Record<string, boolean>;
+  currentUserId: string | null;
+  init: (userId: string) => void;
   markAsSeen: () => void;
-  markSpotlightSeen: () => void;
+  markTourSeen: (key: string) => void;
 }
 
-export const useOnboardingStore = create<OnboardingState>()(
-  persist(
-    (set) => ({
-      hasSeenOnboarding: false,
-      hasSeenSpotlight: false,
-      markAsSeen: () => set({ hasSeenOnboarding: true }),
-      markSpotlightSeen: () => set({ hasSeenSpotlight: true }),
-    }),
-    {
-      name: "solmate-onboarding",
-      storage: createJSONStorage(() => localStorage),
-    }
-  )
-);
+// ─── localStorage 헬퍼 ────────────────────────────────────────────────────────
+
+const storageKey = (userId: string) => `solmate-onboarding-${userId}`;
+
+function loadState(userId: string) {
+  try {
+    const raw = localStorage.getItem(storageKey(userId));
+    if (!raw) return { hasSeenOnboarding: false, seenTours: {} };
+    return JSON.parse(raw) as { hasSeenOnboarding: boolean; seenTours: Record<string, boolean> };
+  } catch {
+    return { hasSeenOnboarding: false, seenTours: {} };
+  }
+}
+
+function saveState(
+  userId: string,
+  hasSeenOnboarding: boolean,
+  seenTours: Record<string, boolean>,
+) {
+  localStorage.setItem(storageKey(userId), JSON.stringify({ hasSeenOnboarding, seenTours }));
+}
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
+  hasSeenOnboarding: false,
+  seenTours: {},
+  currentUserId: null,
+
+  // 로그인 후 유저 ID로 해당 유저의 상태를 불러옴
+  init: (userId: string) => {
+    const saved = loadState(userId);
+    set({ currentUserId: userId, ...saved });
+  },
+
+  markAsSeen: () => {
+    const { currentUserId, seenTours } = get();
+    set({ hasSeenOnboarding: true });
+    if (currentUserId) saveState(currentUserId, true, seenTours);
+  },
+
+  markTourSeen: (key: string) => {
+    const { currentUserId, hasSeenOnboarding, seenTours } = get();
+    const updated = { ...seenTours, [key]: true };
+    set({ seenTours: updated });
+    if (currentUserId) saveState(currentUserId, hasSeenOnboarding, updated);
+  },
+}));

--- a/src/store/onboardingStore.ts
+++ b/src/store/onboardingStore.ts
@@ -9,6 +9,7 @@ interface OnboardingState {
   init: (userId: string) => void;
   markAsSeen: () => void;
   markTourSeen: (key: string) => void;
+  resetTour: (key: string) => void;
 }
 
 // ─── localStorage 헬퍼 ────────────────────────────────────────────────────────
@@ -55,6 +56,13 @@ export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
   markTourSeen: (key: string) => {
     const { currentUserId, hasSeenOnboarding, seenTours } = get();
     const updated = { ...seenTours, [key]: true };
+    set({ seenTours: updated });
+    if (currentUserId) saveState(currentUserId, hasSeenOnboarding, updated);
+  },
+
+  resetTour: (key: string) => {
+    const { currentUserId, hasSeenOnboarding, seenTours } = get();
+    const updated = { ...seenTours, [key]: false };
     set({ seenTours: updated });
     if (currentUserId) saveState(currentUserId, hasSeenOnboarding, updated);
   },

--- a/src/store/onboardingStore.ts
+++ b/src/store/onboardingStore.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+interface OnboardingState {
+  hasSeenOnboarding: boolean;
+  hasSeenSpotlight: boolean;
+  markAsSeen: () => void;
+  markSpotlightSeen: () => void;
+}
+
+export const useOnboardingStore = create<OnboardingState>()(
+  persist(
+    (set) => ({
+      hasSeenOnboarding: false,
+      hasSeenSpotlight: false,
+      markAsSeen: () => set({ hasSeenOnboarding: true }),
+      markSpotlightSeen: () => set({ hasSeenSpotlight: true }),
+    }),
+    {
+      name: "solmate-onboarding",
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #46 

## 💡 작업 배경
  처음 주식을 접하는 사람들을 위한 서비스이기 때문에 온보딩 오버레이 개편과 페이지별 코치마크(SpotlightTour) 시스템을 구현했습니다.

## 🧩 작업 내용

- SpotlightTour
  SVG 마스크 스포트라이트 + 툴팁, tourKey·steps로 페이지별 투어
  툴팁 자동 플립, 스크롤 시 타깃 추적, items·labelColor 지원

-적용 페이지
  홈·모의투자 리스트·종목 상세·내 계좌·매매일지·유저 목록·프로필·멘토·멘티·주문 모달 등 (단계 수는 표와 동일)

-온보딩 스토어
  유저별 localStorage, seenTours로 투어별 완료 분리, resetTour(key)로 개별 초기화

- 가이드 다시보기
  투어 완료 후 우상단 ? 버튼 → 해당 투어만 처음부터 (첫 슬라이드 온보딩은 미재생)

- OnboardingOverlay
  슬라이드를 서비스 기능 중심으로 재구성

## 📸 스크린샷(선택)


## 📝 기타

STOMP가 REST보다 먼저 와 빈 배열로 캐시 덮이던 현상 수정
homeApi staleTime 60s로 REST·STOMP 캐시 충돌 완화