### PR TITLE
[Refactor] 예수금, 보유 현금 용어 통일

### DIFF
--- a/src/components/stocks/HoldingStatus.tsx
+++ b/src/components/stocks/HoldingStatus.tsx
@@ -60,7 +60,7 @@ export default function HoldingStatus({ holding, cash, onBuy, onSell }: Props) {
       </div>
 
       <div className="border-t border-gray-100 pt-3">
-        <p className="text-[13px] text-gray-400 mb-1">보유 현금</p>
+        <p className="text-[13px] text-gray-400 mb-1">주문 가능 금액</p>
         <p className="text-[18px] font-bold text-gray-900">
           {cash != null ? `${cash.toLocaleString()}원` : "-"}
         </p>

--- a/src/pages/account/AccountPage.tsx
+++ b/src/pages/account/AccountPage.tsx
@@ -95,9 +95,9 @@ export default function AccountPage() {
           </p>
         </div>
 
-        {/* 보유 현금 */}
+        {/* 주문 가능 금액 */}
         <div className="bg-white rounded-2xl border border-gray-100 px-6 py-5" data-tour="account-cash">
-          <p className="text-[13px] text-gray-400 font-medium mb-2">보유 현금</p>
+          <p className="text-[13px] text-gray-400 font-medium mb-2">주문 가능 금액</p>
           <p className="text-[22px] font-bold text-gray-900">{fmt(summary?.cash ?? 0)}</p>
           <p className="text-[12px] text-gray-400 mt-1">투자원금 {fmt(summary?.initialCash ?? 0)}</p>
         </div>


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #84 

## 💡 작업 배경
예수금, 보유 현금 용어 헷갈림.

## 🧩 작업 내용
보유 현금을 주문 가능 금액으로 바꾸고 
주문 가능 금액 = 예수금 - 미체결 금액 

