### PR TITLE
[Chore] api 앤드포인트 변경

### DIFF
--- a/src/api/stockApi.ts
+++ b/src/api/stockApi.ts
@@ -287,7 +287,7 @@ export function useCancelOrderMutation(tickerCode: string) {
   return useMutation({
     mutationFn: (orderId: number) =>
       fetchClient.patch<ApiResponse<void>>(
-        `/api/v1/orders/${orderId}/cancel`,
+        `/api/orders/${orderId}/cancel`,
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #92

## 💡 작업 배경
주문 취소 API 연결이 안되고 있음.

## 🧩 작업 내용
주문 취소 API 앤드포인트가 잘못 되어있었음 -> 변경

## 📸 스크린샷(선택)
<img width="1222" height="223" alt="image" src="https://github.com/user-attachments/assets/8db9e9ae-3f29-4e66-8193-e6bd9f5ab095" />

## 📝 기타