### PR TITLE
멘토/멘티/프로필 매매일지 탭 UI 개선 및 댓글 등록 기능 연동

### DIFF
--- a/src/components/profile/MenteeTradeDiaryTab.tsx
+++ b/src/components/profile/MenteeTradeDiaryTab.tsx
@@ -1,51 +1,250 @@
 import { useState } from "react";
+import { ChevronLeft, Search } from "lucide-react";
 import Badge from "@/components/ui/Badge";
 import Avatar from "@/components/ui/Avatar";
+import Button from "@/components/ui/Button";
 import { useUser } from "@/store/authStore";
-import { useMyProfileQuery } from "@/api/userListApi";
+import { useMyProfileQuery, useUserListQuery } from "@/api/userListApi";
 import type { MyDiariesItem } from "@/api/tradeDiaryApi";
+import {
+  useDiaryDetailQuery,
+  usePostCommentMutation,
+  useModifyCommentMutation,
+  useDeleteCommentMutation,
+} from "@/api/tradeDiaryApi";
+import { useStocksQuery } from "@/api/stockApi";
 
 type Props = {
   items: MyDiariesItem[];
-  onFeedback?: (diaryId: number, content: string) => Promise<void>;
 };
 
-function FeedbackInput({ diaryId, onSubmit }: { diaryId: number; onSubmit: (diaryId: number, content: string) => Promise<void> }) {
+function formatDateTime(createdAt: string) {
+  const date = new Date(createdAt);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  return `${y}.${m}.${d} ${hh}:${mm}`;
+}
+
+function formatPrice(price: number) {
+  return price.toLocaleString("ko-KR") + "원";
+}
+
+function formatTotal(price: number, quantity: number) {
+  const total = price * quantity;
+  const manwon = total / 10000;
+  return `${manwon % 1 === 0 ? manwon : manwon.toFixed(1)}만원`;
+}
+
+function formatDate(createdAt: string) {
+  const d = new Date(createdAt);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  const isSameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+  if (isSameDay(d, today)) return "오늘";
+  if (isSameDay(d, yesterday)) return "어제";
+  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
+}
+
+function formatTime(createdAt: string) {
+  const d = new Date(createdAt);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function groupByDate(items: MyDiariesItem[]) {
+  const map = new Map<string, MyDiariesItem[]>();
+  for (const item of items) {
+    const key = formatDate(item.createdAt);
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(item);
+  }
+  return Array.from(map.entries());
+}
+
+function DiaryDetail({ diaryId, onBack }: { diaryId: string; onBack: () => void }) {
   const user = useUser();
   const { data: myProfile } = useMyProfileQuery();
-  const [value, setValue] = useState("");
-  const [loading, setLoading] = useState(false);
+  const { data: userListData } = useUserListQuery();
+  const imageUrlMap = new Map((userListData?.users ?? []).map((u) => [u.nickname, u.imageUrl]));
+  const { data: detail, isLoading } = useDiaryDetailQuery(diaryId);
+  const { mutate: postComment, isPending } = usePostCommentMutation(diaryId);
+  const { mutate: modifyComment } = useModifyCommentMutation(diaryId);
+  const { mutate: deleteComment } = useDeleteCommentMutation(diaryId);
+  const [commentInput, setCommentInput] = useState("");
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const [editInput, setEditInput] = useState("");
 
-  const handleSubmit = async () => {
-    if (!value.trim() || loading) return;
-    setLoading(true);
-    try {
-      await onSubmit(diaryId, value.trim());
-      setValue("");
-    } finally {
-      setLoading(false);
-    }
-  };
+  if (isLoading) {
+    return <div className="py-12 text-center text-[14px] text-gray-400">불러오는 중...</div>;
+  }
+
+  if (!detail) return null;
+
+  const isBuy = detail.tradeType === "BUY";
+  const tradeTypeLabel = isBuy ? "매수" : "매도";
+  const isProfit = (detail.profit ?? 0) >= 0;
+  const profitColor = isProfit ? "text-[#FF4444]" : "text-[#0046FF]";
 
   return (
-    <div className="flex flex-col gap-1.5 mt-1">
-      <p className="text-[12px] font-semibold text-gray-500">멘토 피드백</p>
-      <div className="flex items-center gap-2">
-        <Avatar name={user?.nickname ?? ""} src={myProfile?.imageUrl} size={28} />
-        <div className="flex flex-1 items-center gap-2 border border-gray-200 rounded-xl px-3 py-2 focus-within:border-[#0046FF] transition-colors">
+    <div className="flex flex-col gap-4">
+      {/* 뒤로가기 */}
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1 text-[13px] text-gray-500 hover:text-gray-800 transition-colors w-fit"
+      >
+        <ChevronLeft size={16} />
+        매매일지 목록
+      </button>
+
+      {/* 일지 카드 */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-5 flex flex-col gap-4">
+        {/* 종목 정보 */}
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-2">
+            <span className={`px-2 py-0.5 text-[12px] font-semibold text-white rounded ${isBuy ? "bg-[#FF4444]" : "bg-[#0046FF]"}`}>
+              {tradeTypeLabel}
+            </span>
+            <span className="text-[18px] font-bold text-gray-900">{detail.stockName}</span>
+            <span className="text-[12px] text-gray-400">{detail.tickerCode}</span>
+          </div>
+          {detail.tradeType === "SELL" && (
+            <p className={`text-[16px] font-bold ${profitColor}`}>
+              {isProfit ? "+" : ""}{detail.profit.toLocaleString()} 원
+            </p>
+          )}
+        </div>
+
+        {/* 요약 */}
+        <p className="text-[13px] text-gray-400">
+          {detail.quantity}주 · {formatPrice(detail.filledPrice)} · {formatDateTime(detail.createdAt)}
+        </p>
+
+        {/* 체결 그리드 */}
+        <div className="grid grid-cols-3 divide-x divide-gray-100 border border-gray-100 rounded-xl overflow-hidden">
+          {[
+            { label: "체결수량", value: `${detail.quantity}주` },
+            { label: "체결가격", value: detail.filledPrice ? formatPrice(detail.filledPrice) : "-" },
+            { label: "총 체결금액", value: formatTotal(detail.filledPrice, detail.quantity) },
+          ].map(({ label, value }) => (
+            <div key={label} className="flex flex-col items-center py-3 gap-1">
+              <span className="text-[12px] text-gray-400">{label}</span>
+              <span className="text-[14px] font-semibold text-gray-900">{value}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* 매매 일지 */}
+        <div>
+          <p className="text-[14px] text-gray-400 mb-1">매매 일지</p>
+          <p className="text-[16px] text-gray-700 leading-relaxed">{detail.content}</p>
+        </div>
+      </div>
+
+      {/* 댓글 카드 */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-5 flex flex-col gap-4">
+        <p className="text-[14px] font-semibold text-gray-900">댓글 ({detail.comments?.length ?? 0})</p>
+
+        {/* 댓글 목록 */}
+        <div className="flex flex-col gap-3">
+          {detail.comments?.map((comment) => (
+            <div key={comment.commentId} className="flex gap-3">
+              <Avatar name={comment.nickname} src={imageUrlMap.get(comment.nickname) || comment.imageUrl || undefined} size={32} />
+              <div className="flex flex-col gap-0.5 flex-1">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[13px] font-semibold text-gray-900">{comment.nickname}</span>
+                    {comment.isMentor && (
+                      <span className="px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                        <Badge name="멘토" color="#FF9900" />
+                      </span>
+                    )}
+                  </div>
+                  {user?.nickname === comment.nickname && editingCommentId !== comment.commentId && (
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="basic"
+                        className="text-[11px] px-2 py-0.5"
+                        onClick={() => {
+                          setEditingCommentId(comment.commentId);
+                          setEditInput(comment.content);
+                        }}
+                      >
+                        수정
+                      </Button>
+                      <Button
+                        variant="basic"
+                        className="text-[11px] px-2 py-0.5 border-red-500! text-red-500! hover:bg-red-50!"
+                        onClick={() => deleteComment(comment.commentId)}
+                      >
+                        삭제
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                {editingCommentId === comment.commentId ? (
+                  <div className="flex items-center gap-2 mt-1">
+                    <input
+                      type="text"
+                      value={editInput}
+                      onChange={(e) => setEditInput(e.target.value)}
+                      className="flex-1 px-3 py-1.5 text-[13px] bg-gray-50 border border-gray-200 rounded-xl outline-none focus:border-[#0046FF] transition-colors"
+                    />
+                    <Button
+                      variant="basic"
+                      className="text-[12px] px-2 py-0.5"
+                      onClick={() => {
+                        if (!editInput.trim()) return;
+                        modifyComment(
+                          { commentId: comment.commentId, content: editInput },
+                          { onSuccess: () => setEditingCommentId(null) }
+                        );
+                      }}
+                    >
+                      저장
+                    </Button>
+                    <Button
+                      variant="basic"
+                      className="text-[12px] px-2 py-0.5"
+                      onClick={() => setEditingCommentId(null)}
+                    >
+                      취소
+                    </Button>
+                  </div>
+                ) : (
+                  <p className="text-[12px] text-gray-700 leading-relaxed">{comment.content}</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* 댓글 입력 */}
+        <div className="flex items-center gap-2">
+          <Avatar name={user?.nickname ?? ""} src={myProfile?.imageUrl} size={32} />
           <input
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+            type="text"
+            value={commentInput}
+            onChange={(e) => setCommentInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && commentInput.trim()) {
+                postComment(commentInput, { onSuccess: () => setCommentInput("") });
+              }
+            }}
             placeholder="피드백을 남겨주세요..."
-            className="flex-1 text-[13px] outline-none bg-transparent text-gray-700 placeholder:text-gray-400"
+            className="flex-1 px-4 py-2 text-[14px] bg-gray-50 border border-gray-200 rounded-xl outline-none focus:border-[#0046FF] transition-colors"
           />
           <button
-            onClick={handleSubmit}
-            disabled={!value.trim() || loading}
-            className="text-[12px] font-semibold text-white bg-[#0046FF] px-3 py-1 rounded-lg disabled:opacity-40 transition-opacity shrink-0"
+            disabled={isPending || !commentInput.trim()}
+            onClick={() => postComment(commentInput, { onSuccess: () => setCommentInput("") })}
+            className="px-4 py-2 text-[14px] font-semibold text-white bg-[#0046FF] rounded-xl hover:bg-blue-700 transition-colors disabled:opacity-50"
           >
-            {loading ? "등록 중" : "등록"}
+            등록
           </button>
         </div>
       </div>
@@ -53,49 +252,87 @@ function FeedbackInput({ diaryId, onSubmit }: { diaryId: number; onSubmit: (diar
   );
 }
 
-export default function MenteeTradeDiaryTab({ items, onFeedback }: Props) {
-  if (items.length === 0) {
-    return (
-      <div className="text-center py-12 text-[14px] text-gray-400">
-        매매일지가 없습니다.
-      </div>
-    );
+export default function MenteeTradeDiaryTab({ items }: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const { data: stocks = [] } = useStocksQuery();
+  const logoMap = new Map(stocks.map((s) => [s.stockName, s.stockLogo]));
+
+  if (selectedId) {
+    return <DiaryDetail diaryId={selectedId} onBack={() => setSelectedId(null)} />;
   }
 
-  return (
-    <div className="flex flex-col">
-      {items.map((item) => {
-        const isBuy = item.tradeType === "BUY";
-        const isPositive = (item.profit ?? 0) >= 0;
+  const filtered = items.filter((item) =>
+    item.stockName.toLowerCase().includes(search.toLowerCase())
+  );
+  const grouped = groupByDate(filtered);
 
-        return (
-          <div
-            key={item.diaryId}
-            className="flex flex-col gap-2 px-6 py-5 border-b border-gray-100 last:border-b-0"
-          >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Badge name={isBuy ? "매수" : "매도"} color={isBuy ? "#FF4444" : "#0046FF"} />
-                <span className="text-[15px] font-bold text-gray-900">{item.stockName}</span>
-                <span className="text-[13px] text-gray-400">{item.quantity}주</span>
-                <span className="text-gray-300">·</span>
-                <span className="text-[13px] text-gray-400">{item.filledPrice?.toLocaleString() ?? "-"}원</span>
-                <span className="text-gray-300">·</span>
-                <span className="text-[13px] text-gray-400">{item.createdAt.slice(0, 10).replace(/-/g, ".")}</span>
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="relative">
+        <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
+        <input
+          type="text"
+          placeholder="종목명으로 검색"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full pl-10 pr-4 py-2.5 text-[14px] bg-gray-50 border border-gray-200 rounded-2xl outline-none focus:border-[#0046FF] transition-colors"
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 text-[14px] text-gray-400">
+          {search ? "검색 결과가 없습니다." : "매매일지가 없습니다."}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {grouped.map(([dateLabel, groupItems]) => (
+            <div key={dateLabel} className="flex flex-col gap-1">
+              <p className="text-[12px] font-semibold text-gray-400 px-1 mb-1">{dateLabel}</p>
+              <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden divide-y divide-gray-100">
+                {groupItems.map((item) => {
+                  const isBuy = item.tradeType === "BUY";
+                  const isPositive = item.profit > 0;
+                  return (
+                    <div
+                      key={item.diaryId}
+                      onClick={() => setSelectedId(item.diaryId)}
+                      className="flex items-center justify-between gap-4 px-5 py-4 hover:bg-gray-50 transition-colors cursor-pointer"
+                    >
+                      <div className="flex items-center gap-3 w-52 shrink-0">
+                        <Avatar name={item.stockName} src={logoMap.get(item.stockName)} size={40} />
+                        <div className="flex flex-col gap-0.5 min-w-0">
+                          <div className="flex items-center gap-1.5 flex-wrap">
+                            <span className="text-[15px] font-bold text-gray-900">{item.stockName}</span>
+                            <Badge name={isBuy ? "매수" : "매도"} color={isBuy ? "#FF4444" : "#0046FF"} />
+                          </div>
+                          <span className="text-[12px] text-gray-400">
+                            {item.quantity}주 · {item.filledPrice?.toLocaleString()}원
+                          </span>
+                          <span className="text-[12px] text-gray-400">{formatTime(item.createdAt)}</span>
+                        </div>
+                      </div>
+                      <div className="flex flex-1 items-start justify-between gap-4 min-w-0">
+                        <div className="flex flex-col gap-1 flex-1 min-w-0">
+                          <p className="text-[14px] text-gray-700 leading-relaxed line-clamp-2">{item.content}</p>
+                          {item.commentCount > 0 && (
+                            <span className="text-[11px] text-gray-400 mt-1">댓글 {item.commentCount}</span>
+                          )}
+                        </div>
+                        {!isBuy && (
+                          <span className={`text-[15px] font-bold shrink-0 ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
+                            {isPositive ? "+" : ""}{item.profit?.toLocaleString()}원
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
-              {item.profit != null && item.profit !== 0 && (
-                <span className={`text-[13px] font-semibold ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
-                  {isPositive ? "+" : ""}{item.profit?.toLocaleString()}원
-                </span>
-              )}
             </div>
-            <p className="text-[14px] text-gray-700 leading-relaxed">{item.content}</p>
-            {onFeedback && (
-              <FeedbackInput diaryId={item.diaryId} onSubmit={onFeedback} />
-            )}
-          </div>
-        );
-      })}
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/profile/MentorTradeDiaryTab.tsx
+++ b/src/components/profile/MentorTradeDiaryTab.tsx
@@ -1,98 +1,338 @@
 import { useState } from "react";
+import { ChevronLeft, Search } from "lucide-react";
 import Badge from "@/components/ui/Badge";
 import Avatar from "@/components/ui/Avatar";
+import Button from "@/components/ui/Button";
 import { useUser } from "@/store/authStore";
-import { useMyProfileQuery } from "@/api/userListApi";
+import { useMyProfileQuery, useUserListQuery } from "@/api/userListApi";
 import type { MyDiariesItem } from "@/api/tradeDiaryApi";
+import {
+  useDiaryDetailQuery,
+  usePostCommentMutation,
+  useModifyCommentMutation,
+  useDeleteCommentMutation,
+} from "@/api/tradeDiaryApi";
+import { useStocksQuery } from "@/api/stockApi";
 
 type Props = {
   items: MyDiariesItem[];
-  onAskQuestion?: (diaryId: number, content: string) => Promise<void>;
 };
 
-function QuestionInput({ diaryId, onSubmit }: { diaryId: number; onSubmit: (diaryId: number, content: string) => Promise<void> }) {
+function formatDateTime(createdAt: string) {
+  const date = new Date(createdAt);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  return `${y}.${m}.${d} ${hh}:${mm}`;
+}
+
+function formatPrice(price: number) {
+  return price.toLocaleString("ko-KR") + "원";
+}
+
+function formatTotal(price: number, quantity: number) {
+  const total = price * quantity;
+  const manwon = total / 10000;
+  return `${manwon % 1 === 0 ? manwon : manwon.toFixed(1)}만원`;
+}
+
+function formatDate(createdAt: string) {
+  const d = new Date(createdAt);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  const isSameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+  if (isSameDay(d, today)) return "오늘";
+  if (isSameDay(d, yesterday)) return "어제";
+  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
+}
+
+function formatTime(createdAt: string) {
+  const d = new Date(createdAt);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function groupByDate(items: MyDiariesItem[]) {
+  const map = new Map<string, MyDiariesItem[]>();
+  for (const item of items) {
+    const key = formatDate(item.createdAt);
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(item);
+  }
+  return Array.from(map.entries());
+}
+
+function DiaryDetail({ diaryId, onBack }: { diaryId: string; onBack: () => void }) {
   const user = useUser();
   const { data: myProfile } = useMyProfileQuery();
-  const [value, setValue] = useState("");
-  const [loading, setLoading] = useState(false);
+  const { data: userListData } = useUserListQuery();
+  const imageUrlMap = new Map((userListData?.users ?? []).map((u) => [u.nickname, u.imageUrl]));
+  const { data: detail, isLoading } = useDiaryDetailQuery(diaryId);
+  const { mutate: postComment, isPending } = usePostCommentMutation(diaryId);
+  const { mutate: modifyComment } = useModifyCommentMutation(diaryId);
+  const { mutate: deleteComment } = useDeleteCommentMutation(diaryId);
+  const [commentInput, setCommentInput] = useState("");
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const [editInput, setEditInput] = useState("");
 
-  const handleSubmit = async () => {
-    if (!value.trim() || loading) return;
-    setLoading(true);
-    try {
-      await onSubmit(diaryId, value.trim());
-      setValue("");
-    } finally {
-      setLoading(false);
-    }
-  };
+  if (isLoading) {
+    return <div className="py-12 text-center text-[14px] text-gray-400">불러오는 중...</div>;
+  }
+
+  if (!detail) return null;
+
+  const isBuy = detail.tradeType === "BUY";
+  const tradeTypeLabel = isBuy ? "매수" : "매도";
+  const isProfit = (detail.profit ?? 0) >= 0;
+  const profitColor = isProfit ? "text-[#FF4444]" : "text-[#0046FF]";
 
   return (
-    <div className="flex items-center gap-2 mt-1">
-      <Avatar name={user?.nickname ?? ""} src={myProfile?.imageUrl} size={28} />
-      <div className="flex flex-1 items-center gap-2 border border-gray-200 rounded-xl px-3 py-2 focus-within:border-[#0046FF] transition-colors">
-        <input
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
-          placeholder="멘토에게 질문하기..."
-          className="flex-1 text-[13px] outline-none bg-transparent text-gray-700 placeholder:text-gray-400"
-        />
-        <button
-          onClick={handleSubmit}
-          disabled={!value.trim() || loading}
-          className="text-[12px] font-semibold text-white bg-[#0046FF] px-3 py-1 rounded-lg disabled:opacity-40 transition-opacity shrink-0"
-        >
-          {loading ? "등록 중" : "등록"}
-        </button>
+    <div className="flex flex-col gap-4">
+      {/* 뒤로가기 */}
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1 text-[13px] text-gray-500 hover:text-gray-800 transition-colors w-fit"
+      >
+        <ChevronLeft size={16} />
+        매매일지 목록
+      </button>
+
+      {/* 일지 카드 */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-5 flex flex-col gap-4">
+        {/* 종목 정보 */}
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-2">
+            <span className={`px-2 py-0.5 text-[12px] font-semibold text-white rounded ${isBuy ? "bg-[#FF4444]" : "bg-[#0046FF]"}`}>
+              {tradeTypeLabel}
+            </span>
+            <span className="text-[18px] font-bold text-gray-900">{detail.stockName}</span>
+            <span className="text-[12px] text-gray-400">{detail.tickerCode}</span>
+          </div>
+          {detail.tradeType === "SELL" && (
+            <p className={`text-[16px] font-bold ${profitColor}`}>
+              {isProfit ? "+" : ""}{detail.profit.toLocaleString()} 원
+            </p>
+          )}
+        </div>
+
+        {/* 요약 */}
+        <p className="text-[13px] text-gray-400">
+          {detail.quantity}주 · {formatPrice(detail.filledPrice)} · {formatDateTime(detail.createdAt)}
+        </p>
+
+        {/* 체결 그리드 */}
+        <div className="grid grid-cols-3 divide-x divide-gray-100 border border-gray-100 rounded-xl overflow-hidden">
+          {[
+            { label: "체결수량", value: `${detail.quantity}주` },
+            { label: "체결가격", value: detail.filledPrice ? formatPrice(detail.filledPrice) : "-" },
+            { label: "총 체결금액", value: formatTotal(detail.filledPrice, detail.quantity) },
+          ].map(({ label, value }) => (
+            <div key={label} className="flex flex-col items-center py-3 gap-1">
+              <span className="text-[12px] text-gray-400">{label}</span>
+              <span className="text-[14px] font-semibold text-gray-900">{value}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* 매매 일지 */}
+        <div>
+          <p className="text-[14px] text-gray-400 mb-1">매매 일지</p>
+          <p className="text-[16px] text-gray-700 leading-relaxed">{detail.content}</p>
+        </div>
+      </div>
+
+      {/* 댓글 카드 */}
+      <div className="bg-white rounded-2xl border border-gray-100 p-5 flex flex-col gap-4">
+        <p className="text-[14px] font-semibold text-gray-900">댓글 ({detail.comments?.length ?? 0})</p>
+
+        {/* 댓글 목록 */}
+        <div className="flex flex-col gap-3">
+          {detail.comments?.map((comment) => (
+            <div key={comment.commentId} className="flex gap-3">
+              <Avatar name={comment.nickname} src={imageUrlMap.get(comment.nickname) || comment.imageUrl || undefined} size={32} />
+              <div className="flex flex-col gap-0.5 flex-1">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[13px] font-semibold text-gray-900">{comment.nickname}</span>
+                    {comment.isMentor && (
+                      <span className="px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                        <Badge name="멘토" color="#FF9900" />
+                      </span>
+                    )}
+                  </div>
+                  {user?.nickname === comment.nickname && editingCommentId !== comment.commentId && (
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="basic"
+                        className="text-[11px] px-2 py-0.5"
+                        onClick={() => {
+                          setEditingCommentId(comment.commentId);
+                          setEditInput(comment.content);
+                        }}
+                      >
+                        수정
+                      </Button>
+                      <Button
+                        variant="basic"
+                        className="text-[11px] px-2 py-0.5 border-red-500! text-red-500! hover:bg-red-50!"
+                        onClick={() => deleteComment(comment.commentId)}
+                      >
+                        삭제
+                      </Button>
+                    </div>
+                  )}
+                </div>
+                {editingCommentId === comment.commentId ? (
+                  <div className="flex items-center gap-2 mt-1">
+                    <input
+                      type="text"
+                      value={editInput}
+                      onChange={(e) => setEditInput(e.target.value)}
+                      className="flex-1 px-3 py-1.5 text-[13px] bg-gray-50 border border-gray-200 rounded-xl outline-none focus:border-[#0046FF] transition-colors"
+                    />
+                    <Button
+                      variant="basic"
+                      className="text-[12px] px-2 py-0.5"
+                      onClick={() => {
+                        if (!editInput.trim()) return;
+                        modifyComment(
+                          { commentId: comment.commentId, content: editInput },
+                          { onSuccess: () => setEditingCommentId(null) }
+                        );
+                      }}
+                    >
+                      저장
+                    </Button>
+                    <Button
+                      variant="basic"
+                      className="text-[12px] px-2 py-0.5"
+                      onClick={() => setEditingCommentId(null)}
+                    >
+                      취소
+                    </Button>
+                  </div>
+                ) : (
+                  <p className="text-[12px] text-gray-700 leading-relaxed">{comment.content}</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* 댓글 입력 */}
+        <div className="flex items-center gap-2">
+          <Avatar name={user?.nickname ?? ""} src={myProfile?.imageUrl} size={32} />
+          <input
+            type="text"
+            value={commentInput}
+            onChange={(e) => setCommentInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && commentInput.trim()) {
+                postComment(commentInput, { onSuccess: () => setCommentInput("") });
+              }
+            }}
+            placeholder="멘토에게 질문하기..."
+            className="flex-1 px-4 py-2 text-[14px] bg-gray-50 border border-gray-200 rounded-xl outline-none focus:border-[#0046FF] transition-colors"
+          />
+          <button
+            disabled={isPending || !commentInput.trim()}
+            onClick={() => postComment(commentInput, { onSuccess: () => setCommentInput("") })}
+            className="px-4 py-2 text-[14px] font-semibold text-white bg-[#0046FF] rounded-xl hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            등록
+          </button>
+        </div>
       </div>
     </div>
   );
 }
 
-export default function MentorTradeDiaryTab({ items, onAskQuestion }: Props) {
-  if (items.length === 0) {
-    return (
-      <div className="text-center py-12 text-[14px] text-gray-400">
-        매매일지가 없습니다.
-      </div>
-    );
+export default function MentorTradeDiaryTab({ items }: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const { data: stocks = [] } = useStocksQuery();
+  const logoMap = new Map(stocks.map((s) => [s.stockName, s.stockLogo]));
+
+  if (selectedId) {
+    return <DiaryDetail diaryId={selectedId} onBack={() => setSelectedId(null)} />;
   }
 
-  return (
-    <div className="flex flex-col">
-      {items.map((item) => {
-        const isBuy = item.tradeType === "BUY";
-        const isPositive = (item.profit ?? 0) >= 0;
+  const filtered = items.filter((item) =>
+    item.stockName.toLowerCase().includes(search.toLowerCase())
+  );
+  const grouped = groupByDate(filtered);
 
-        return (
-          <div
-            key={item.diaryId}
-            className="flex flex-col gap-2 px-6 py-5 border-b border-gray-100 last:border-b-0"
-          >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Badge name={isBuy ? "매수" : "매도"} color={isBuy ? "#FF4444" : "#0046FF"} />
-                <span className="text-[15px] font-bold text-gray-900">{item.stockName}</span>
-                <span className="text-[13px] text-gray-400">{item.quantity}주</span>
-                <span className="text-gray-300">·</span>
-                <span className="text-[13px] text-gray-400">{item.filledPrice?.toLocaleString() ?? "-"}원</span>
-                <span className="text-gray-300">·</span>
-                <span className="text-[13px] text-gray-400">{item.createdAt.slice(0, 10).replace(/-/g, ".")}</span>
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="relative">
+        <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
+        <input
+          type="text"
+          placeholder="종목명으로 검색"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full pl-10 pr-4 py-2.5 text-[14px] bg-gray-50 border border-gray-200 rounded-2xl outline-none focus:border-[#0046FF] transition-colors"
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 text-[14px] text-gray-400">
+          {search ? "검색 결과가 없습니다." : "매매일지가 없습니다."}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {grouped.map(([dateLabel, groupItems]) => (
+            <div key={dateLabel} className="flex flex-col gap-1">
+              <p className="text-[12px] font-semibold text-gray-400 px-1 mb-1">{dateLabel}</p>
+              <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden divide-y divide-gray-100">
+                {groupItems.map((item) => {
+                  const isBuy = item.tradeType === "BUY";
+                  const isPositive = item.profit > 0;
+                  return (
+                    <div
+                      key={item.diaryId}
+                      onClick={() => setSelectedId(item.diaryId)}
+                      className="flex items-center justify-between gap-4 px-5 py-4 hover:bg-gray-50 transition-colors cursor-pointer"
+                    >
+                      <div className="flex items-center gap-3 w-52 shrink-0">
+                        <Avatar name={item.stockName} src={logoMap.get(item.stockName)} size={40} />
+                        <div className="flex flex-col gap-0.5 min-w-0">
+                          <div className="flex items-center gap-1.5 flex-wrap">
+                            <span className="text-[15px] font-bold text-gray-900">{item.stockName}</span>
+                            <Badge name={isBuy ? "매수" : "매도"} color={isBuy ? "#FF4444" : "#0046FF"} />
+                          </div>
+                          <span className="text-[12px] text-gray-400">
+                            {item.quantity}주 · {item.filledPrice?.toLocaleString()}원
+                          </span>
+                          <span className="text-[12px] text-gray-400">{formatTime(item.createdAt)}</span>
+                        </div>
+                      </div>
+                      <div className="flex flex-1 items-start justify-between gap-4 min-w-0">
+                        <div className="flex flex-col gap-1 flex-1 min-w-0">
+                          <p className="text-[14px] text-gray-700 leading-relaxed line-clamp-2">{item.content}</p>
+                          {item.commentCount > 0 && (
+                            <span className="text-[11px] text-gray-400 mt-1">댓글 {item.commentCount}</span>
+                          )}
+                        </div>
+                        {!isBuy && (
+                          <span className={`text-[15px] font-bold shrink-0 ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
+                            {isPositive ? "+" : ""}{item.profit?.toLocaleString()}원
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
-              {item.profit != null && item.profit !== 0 && (
-                <span className={`text-[13px] font-semibold ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
-                  {isPositive ? "+" : ""}{item.profit?.toLocaleString()}원
-                </span>
-              )}
             </div>
-            <p className="text-[14px] text-gray-700 leading-relaxed">{item.content}</p>
-            {onAskQuestion && (
-              <QuestionInput diaryId={item.diaryId} onSubmit={onAskQuestion} />
-            )}
-          </div>
-        );
-      })}
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/profile/TradeDiaryTab.tsx
+++ b/src/components/profile/TradeDiaryTab.tsx
@@ -1,66 +1,120 @@
+import { useState } from "react";
+import { Search } from "lucide-react";
 import Badge from "@/components/ui/Badge";
+import Avatar from "@/components/ui/Avatar";
 import type { MyDiariesItem } from "@/api/tradeDiaryApi";
+import { useStocksQuery } from "@/api/stockApi";
 
 type Props = {
   items: MyDiariesItem[];
 };
 
-export default function TradeDiaryTab({ items }: Props) {
-  if (items.length === 0) {
-    return (
-      <div className="text-center py-12 text-[14px] text-gray-400">
-        매매일지가 없습니다.
-      </div>
-    );
+function formatDate(createdAt: string) {
+  const d = new Date(createdAt);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  const isSameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate();
+  if (isSameDay(d, today)) return "오늘";
+  if (isSameDay(d, yesterday)) return "어제";
+  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
+}
+
+function formatTime(createdAt: string) {
+  const d = new Date(createdAt);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function groupByDate(items: MyDiariesItem[]) {
+  const map = new Map<string, MyDiariesItem[]>();
+  for (const item of items) {
+    const key = formatDate(item.createdAt);
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(item);
   }
+  return Array.from(map.entries());
+}
+
+export default function TradeDiaryTab({ items }: Props) {
+  const [search, setSearch] = useState("");
+  const { data: stocks = [] } = useStocksQuery();
+  const logoMap = new Map(stocks.map((s) => [s.stockName, s.stockLogo]));
+
+  const filtered = items.filter((item) =>
+    item.stockName.toLowerCase().includes(search.toLowerCase())
+  );
+  const grouped = groupByDate(filtered);
 
   return (
-    <div className="flex flex-col">
-      {items.map((item) => {
-        const isBuy = item.tradeType === "BUY";
-        const isPositive = (item.profit ?? 0) >= 0;
+    <div className="flex flex-col gap-4">
+      {/* 검색 */}
+      <div className="relative">
+        <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
+        <input
+          type="text"
+          placeholder="종목명으로 검색"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full pl-10 pr-4 py-2.5 text-[14px] bg-gray-50 border border-gray-200 rounded-2xl outline-none focus:border-[#0046FF] transition-colors"
+        />
+      </div>
 
-        return (
-          <div
-            key={item.diaryId}
-            className="flex flex-col gap-2 px-6 py-5 border-b border-gray-100 last:border-b-0"
-          >
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Badge
-                  name={isBuy ? "매수" : "매도"}
-                  color={isBuy ? "#FF4444" : "#0046FF"}
-                />
-                <span className="text-[15px] font-bold text-gray-900">
-                  {item.stockName}
-                </span>
-                <span className="text-[13px] text-gray-400">{item.quantity}주</span>
-                <span className="text-gray-300">·</span>
-                <span className="text-[13px] text-gray-400">
-                  {item.filledPrice?.toLocaleString() ?? "-"}원
-                </span>
-                <span className="text-gray-300">·</span>
-                <span className="text-[13px] text-gray-400">
-                  {item.createdAt.slice(0, 10).replace(/-/g, ".")}
-                </span>
+      {/* 목록 */}
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 text-[14px] text-gray-400">
+          {search ? "검색 결과가 없습니다." : "매매일지가 없습니다."}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {grouped.map(([dateLabel, groupItems]) => (
+            <div key={dateLabel} className="flex flex-col gap-1">
+              <p className="text-[12px] font-semibold text-gray-400 px-1 mb-1">{dateLabel}</p>
+              <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden divide-y divide-gray-100">
+                {groupItems.map((item) => {
+                  const isBuy = item.tradeType === "BUY";
+                  const isPositive = item.profit > 0;
+                  return (
+                    <div
+                      key={item.diaryId}
+                      className="flex items-center justify-between gap-4 px-5 py-4"
+                    >
+                      {/* 좌측: 종목 정보 */}
+                      <div className="flex items-center gap-3 w-52 shrink-0">
+                        <Avatar name={item.stockName} src={logoMap.get(item.stockName)} size={40} />
+                        <div className="flex flex-col gap-0.5 min-w-0">
+                          <div className="flex items-center gap-1.5 flex-wrap">
+                            <span className="text-[15px] font-bold text-gray-900">{item.stockName}</span>
+                            <Badge name={isBuy ? "매수" : "매도"} color={isBuy ? "#FF4444" : "#0046FF"} />
+                          </div>
+                          <span className="text-[12px] text-gray-400">
+                            {item.quantity}주 · {item.filledPrice?.toLocaleString()}원
+                          </span>
+                          <span className="text-[12px] text-gray-400">{formatTime(item.createdAt)}</span>
+                        </div>
+                      </div>
+
+                      {/* 우측: 내용 + 수익 */}
+                      <div className="flex flex-1 items-start justify-between gap-4 min-w-0">
+                        <p className="text-[14px] text-gray-700 leading-relaxed line-clamp-2 flex-1 min-w-0">
+                          {item.content}
+                        </p>
+                        {!isBuy && (
+                          <span className={`text-[15px] font-bold shrink-0 ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
+                            {isPositive ? "+" : ""}{item.profit?.toLocaleString()}원
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
-              {item.profit != null && item.profit !== 0 && (
-                <span
-                  className={`text-[13px] font-semibold ${
-                    isPositive ? "text-[#FF4444]" : "text-[#0046FF]"
-                  }`}
-                >
-                  {isPositive ? "+" : ""}
-                  {item.profit?.toLocaleString()}원
-                </span>
-              )}
             </div>
-            <p className="text-[14px] text-gray-700 leading-relaxed">
-              {item.content}
-            </p>
-          </div>
-        );
-      })}
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/mentee/MyMenteePage.tsx
+++ b/src/pages/mentee/MyMenteePage.tsx
@@ -147,13 +147,7 @@ function MenteeDetail({ menteeId }: { menteeId: number }) {
         />
         <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
           {activeTab === "diary" && (
-            <MenteeTradeDiaryTab
-              items={diaries}
-              onFeedback={async (diaryId, content) => {
-                // TODO: 피드백 API 연동
-                console.log("피드백 등록:", diaryId, content);
-              }}
-            />
+            <MenteeTradeDiaryTab items={diaries} />
           )}
           {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
           {activeTab === "portfolio" && (

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -223,13 +223,7 @@ export default function MyMentorPage() {
         />
         <div className={`p-5 flex-1 min-h-0 ${activeTab !== "portfolio" ? "overflow-y-auto" : "overflow-hidden"}`}>
           {activeTab === "diary" && (
-            <MentorTradeDiaryTab
-              items={diaries}
-              onAskQuestion={async (diaryId, content) => {
-                // TODO: 질문 API 연동
-                console.log("질문 등록:", diaryId, content);
-              }}
-            />
+            <MentorTradeDiaryTab items={diaries} />
           )}
           {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
           {activeTab === "portfolio" && (


### PR DESCRIPTION
## #️⃣  관련 이슈                                                                                               
 - closed #78
                                                                                                                
  ## 💡 작업 배경 
  나의 멘토/나의 멘티 페이지의 매매일지 탭에서 댓글을 작성해도 등록되지 않는 버그가 있었습니다.
  원인은 `onAskQuestion`, `onFeedback` 핸들러가 실제 API 호출 없이 `console.log`만 하는 TODO 상태였기           
  때문입니다.                                                                                                   
  또한 멘토/멘티/프로필 매매일지 목록의 UI가 매매일지 전용 페이지와 달리 검색, 날짜 그룹핑, 종목 로고 없이 단순 
  텍스트 나열 형태였습니다.                                                                                     
                  
  ## 🧩 작업 내용                                                                                               
  - `MentorTradeDiaryTab`, `MenteeTradeDiaryTab`에서 `onAskQuestion`/`onFeedback` props 제거 후 컴포넌트
  내부에서 `usePostCommentMutation` 직접 호출하도록 수정                                                        
  - 나의 멘토/나의 멘티 매매일지 탭에 목록 ↔ 상세 in-tab 전환 구조 추가
    - 목록: 종목명 검색, 날짜별 그룹핑, 종목 로고 카드 레이아웃, 댓글 수 표시                                   
    - 상세: 체결 정보 그리드, 매매 일지 내용, 댓글 목록(수정/삭제), 댓글 입력                                   
  - `TradeDiaryTab`(내 프로필/타인 프로필)도 동일한 목록 스타일로 개선 (검색, 날짜 그룹핑, 종목 로고) - 읽기    
  전용                                                                                                          
  - `MyMentorPage`, `MyMenteePage`에서 불필요해진 TODO 핸들러 제거                                              
                                                                                                                
  ## 📸 스크린샷(선택)
                                                                                                                
                  
  ## 📝 기타