### PR TITLE
[Fix] 백엔드 에러 메세지 담도록 수정

### DIFF
--- a/src/lib/fetchClient.ts
+++ b/src/lib/fetchClient.ts
@@ -49,7 +49,13 @@ async function request<T>(
     }
   }
 
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => null);
+    const err = new Error(`HTTP ${res.status}`) as Error & { status: number; data: unknown };
+    err.status = res.status;
+    err.data = errorData;
+    throw err;
+  }
   return res.json() as Promise<T>;
 }
 

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import Input from "../../components/ui/Input";
 import Button from "../../components/ui/Button";
 import Logo from "@/components/ui/Logo";
@@ -45,6 +45,7 @@ function GoogleIcon() {
 // ─── Main Component ───────────────────────────────────────────────────────────
 export default function LoginPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const setAuth = useAuthStore((s) => s.setAuth);
 
   const [form, setForm] = useState<LoginForm>({
@@ -55,7 +56,7 @@ export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
-  const [errorMsg, setErrorMsg] = useState("");
+  const [errorMsg, setErrorMsg] = useState((location.state as { errorMsg?: string })?.errorMsg ?? "");
 
   const setField = <K extends keyof LoginForm>(key: K, value: LoginForm[K]) =>
     setForm((prev) => ({ ...prev, [key]: value }));

--- a/src/pages/auth/OauthCallbackPage.tsx
+++ b/src/pages/auth/OauthCallbackPage.tsx
@@ -31,7 +31,12 @@ export default function OAuthCallbackPage() {
       })
       .catch((err) => {
         console.error("[OAuth] 에러:", err.message);
-        navigate("/login", { replace: true });
+        const code = (err?.data as { code?: string; message?: string })?.code;
+        const message =
+          code === "USER_409_1"
+            ? (err.data as { message: string }).message
+            : "구글 로그인에 실패했습니다. 다시 시도해 주세요.";
+        navigate("/login", { replace: true, state: { errorMsg: message } });
       });
   }, [navigate, searchParams, setAuth]);
 

--- a/src/pages/auth/SignUpPage.tsx
+++ b/src/pages/auth/SignUpPage.tsx
@@ -164,8 +164,13 @@ export default function SignUpPage() {
       await authApi.signup({ email, nickname: nickname.trim(), password });
       showToast("회원가입이 완료되었습니다!");
       navigate("/login");
-    } catch {
-      showToast("회원가입에 실패했습니다. 다시 시도해 주세요.");
+    } catch (err: unknown) {
+      const data = (err as { data?: { code?: string; message?: string } })?.data;
+      if ((data?.code === "USER_409_2" || data?.code === "USER_409") && data.message) {
+        showToast(data.message);
+      } else {
+        showToast("회원가입에 실패했습니다. 다시 시도해 주세요.");
+      }
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #101

## 💡 작업 배경
  일반 이메일로 가입된 계정으로 구글 로그인을 시도하거나,  구글로 가입된 이메일로 일반 회원가입을 시도할 때  아무런 안내 없이 로그인 화면으로 돌아가거나 일반 에러 메세지만 표시되어 사용자가 원인을 알 수 없는 문제가 있다.

## 🧩 작업 내용
  - fetchClient가 에러 응답 body를 err.data에 담아 throw하도록 수정             
    (기존에는 new Error('HTTP 409')만 던져 응답 body 접근 불가)                 
  - 구글 로그인 시 USER_409_1: 백엔드 메세지를 로그인 페이지로 전달해 에러 문구 표시                                                                          
  - 일반 회원가입 시 USER_409_2 / USER_409: 백엔드 메세지를 토스트로 표시 

## 📸 스크린샷(선택)
<img width="672" height="630" alt="Screenshot 2026-03-27 at 7 47 08 PM" src="https://github.com/user-attachments/assets/4c29f974-89bf-4ab5-8918-e142bc313728" />
<img width="455" height="633" alt="Screenshot 2026-03-27 at 7 47 27 PM" src="https://github.com/user-attachments/assets/9912ff31-5308-49b6-a0f0-17f46ecb1fdf" />

## 📝 기타

