### PR TITLE
[Refactor] 시장 지수 변화율 음수 부호 중복 표시 제거

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -153,7 +153,7 @@ function MarketIndexCard({ index }: { index: MarketIndexData }) {
           <TrendingDown size={12} className="text-blue-600" />
         )}
         <ReturnText
-          value={`${index.isPositive ? "▲" : "▼"}${index.change} (${index.isPositive ? "+" : "-"}${index.changePercent}%)`}
+          value={`${index.isPositive ? "▲" : "▼"}${index.change} (${index.isPositive ? "+" : ""}${index.changePercent}%)`}
           isPositive={index.isPositive}
           className="text-[12px] font-medium"
         />

--- a/src/pages/stocks/StockList.tsx
+++ b/src/pages/stocks/StockList.tsx
@@ -116,7 +116,7 @@ function MarketPanel({
               className={`text-[12px] font-medium ${idx.isPositive ? "text-red-500" : "text-blue-600"}`}
             >
               {idx.isPositive ? "▲" : "▼"}
-              {idx.change} ({idx.isPositive ? "+" : "-"}
+              {idx.change} ({idx.isPositive ? "+" : ""}
               {idx.changePercent}%)
             </span>
           </div>


### PR DESCRIPTION
## #️⃣  관련 이슈
  - closed #108 
                                                                                                                
  ## 💡 작업 배경
  KOSPI, KOSDAQ, USD/KRW 지수의 변화율 값이 API에서 이미 음수 부호(-)를 포함해서 내려오는데, 렌더링 시 음수일 때
   `-`를 추가로 붙여 `--5.08%` 형태로 이중 표시되는 버그가 있었음                                               
   
  ## 🧩 작업 내용                                                                                               
  - `HomePage.tsx`: 시장 지수 변화율 표시 시 음수 조건에서 `-` 추가하던 부분 제거
  - `StockList.tsx`: 동일 로직 동일하게 수정                                                                    
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
                                                                                                                
  ## 📝 기타