### PR TITLE
[Refactor] 컴포넌트별 STOMP 클라이언트를 싱글톤으로 교체

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,9 +1,8 @@
 // src/components/layout/Layout.tsx
 import { useEffect } from "react";
 import { Outlet } from "react-router-dom";
-import { Client } from "@stomp/stompjs";
-import SockJS from "sockjs-client";
 import { useQueryClient } from "@tanstack/react-query";
+import { stompSubscribe } from "@/lib/stompClient";
 import {
   parseMarketIndicatorMessage,
   homeQueryKeys,
@@ -37,32 +36,21 @@ export default function Layout() {
   }, [accessToken]);
 
   useEffect(() => {
-    const wsUrl = (import.meta.env.VITE_API_BASE_URL ?? "") + "/ws";
-    const client = new Client({
-      webSocketFactory: () => new SockJS(wsUrl),
-      onConnect: () => {
-        console.log("[STOMP] 연결됨");
-        client.subscribe("/topic/market/indicators", (message) => {
-          const msg: MarketIndicatorMessage = JSON.parse(message.body);
-          const updated = parseMarketIndicatorMessage(msg);
-          const prev = queryClient.getQueryData<MarketIndexData[]>(
-            homeQueryKeys.marketIndices,
-          );
-          // 캐시가 비어있으면 건드리지 않음 — 초기 REST 요청이 알아서 채움
-          if (!prev || prev.length === 0) return;
-          queryClient.setQueryData<MarketIndexData[]>(
-            homeQueryKeys.marketIndices,
-            prev.map((item) =>
-              item.label === updated.label ? updated : item,
-            ),
-          );
-        });
-      },
-      onDisconnect: () => console.log("[STOMP] 연결 끊김"),
-      onStompError: (frame) => console.error("[STOMP] 에러:", frame),
+    return stompSubscribe("/topic/market/indicators", (message) => {
+      const msg: MarketIndicatorMessage = JSON.parse(message.body);
+      const updated = parseMarketIndicatorMessage(msg);
+      const prev = queryClient.getQueryData<MarketIndexData[]>(
+        homeQueryKeys.marketIndices,
+      );
+      // 캐시가 비어있으면 건드리지 않음 — 초기 REST 요청이 알아서 채움
+      if (!prev || prev.length === 0) return;
+      queryClient.setQueryData<MarketIndexData[]>(
+        homeQueryKeys.marketIndices,
+        prev.map((item) =>
+          item.label === updated.label ? updated : item,
+        ),
+      );
     });
-    client.activate();
-    return () => { client.deactivate(); };
   }, [queryClient]);
 
   return (

--- a/src/lib/stompClient.ts
+++ b/src/lib/stompClient.ts
@@ -1,0 +1,55 @@
+// src/lib/stompClient.ts
+// 앱 전체에서 단 하나의 STOMP 연결을 공유합니다.
+// SockJS 협상(info 요청 + WebSocket 업그레이드)은 최초 1회만 발생합니다.
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+import type { StompSubscription, messageCallbackType } from "@stomp/stompjs";
+
+type SubscriptionEntry = {
+  destination: string;
+  callback: messageCallbackType;
+  subscription?: StompSubscription;
+};
+
+const registry = new Map<symbol, SubscriptionEntry>();
+
+const wsUrl = (import.meta.env.VITE_API_BASE_URL ?? "") + "/ws";
+
+const sharedClient = new Client({
+  webSocketFactory: () => new SockJS(wsUrl),
+  reconnectDelay: 5000,
+  onConnect: () => {
+    // 재연결 시 모든 구독을 자동으로 복구합니다
+    registry.forEach((entry) => {
+      entry.subscription = sharedClient.subscribe(
+        entry.destination,
+        entry.callback,
+      );
+    });
+  },
+});
+
+sharedClient.activate();
+
+/**
+ * STOMP 토픽을 구독합니다.
+ * @returns 구독을 해제하는 cleanup 함수
+ */
+export function stompSubscribe(
+  destination: string,
+  callback: messageCallbackType,
+): () => void {
+  const key = Symbol();
+  const entry: SubscriptionEntry = { destination, callback };
+  registry.set(key, entry);
+
+  if (sharedClient.connected) {
+    entry.subscription = sharedClient.subscribe(destination, callback);
+  }
+  // 미연결 상태면 onConnect에서 자동 구독됩니다
+
+  return () => {
+    entry.subscription?.unsubscribe();
+    registry.delete(key);
+  };
+}

--- a/src/pages/stocks/StockList.tsx
+++ b/src/pages/stocks/StockList.tsx
@@ -50,8 +50,7 @@ import { useMarketIndicesQuery } from "@/api/homeApi";
 import { fetchStocks, parseStockItemMessage } from "@/api/stockApi";
 import type { MarketIndexData } from "@/api/homeApi";
 import type { StockItem, StockItemMessage } from "@/api/stockApi";
-import { Client } from "@stomp/stompjs";
-import SockJS from "sockjs-client";
+import { stompSubscribe } from "@/lib/stompClient";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -200,43 +199,37 @@ export default function StockList() {
   const [sector, setSector] = useState("전체");
   const [sort, setSort] = useState<SortType>("거래량순");
 
-  // ── 초기 fetch 후 STOMP 연결 ────────────────────────────────────────────
+  // ── 초기 fetch 후 STOMP 구독 (공유 클라이언트 재사용) ────────────────────
   useEffect(() => {
     let cancelled = false;
-    let client: Client;
+    const cleanupFns: Array<() => void> = [];
 
     fetchStocks().then((initialStocks) => {
       if (cancelled) return;
       setStocks(initialStocks);
 
-      const wsUrl = (import.meta.env.VITE_API_BASE_URL ?? "") + "/ws";
-      client = new Client({
-        webSocketFactory: () => new SockJS(wsUrl),
-        onConnect: () => {
-          console.log("[STOMP] 연결됨");
-          initialStocks.forEach(({ tickerCode }) => {
-            client.subscribe(`/topic/stocks/${tickerCode}/quote`, (message) => {
-              const msg: StockItemMessage = JSON.parse(message.body);
-              const updated = parseStockItemMessage(msg);
-              setStocks((prev) =>
-                prev.map((item) =>
-                  item.tickerCode === updated.tickerCode
-                    ? { ...item, ...updated }
-                    : item,
-                ),
-              );
-            });
-          });
-        },
-        onDisconnect: () => console.log("[STOMP] 연결 끊김"),
-        onStompError: (frame) => console.error("[STOMP] 에러:", frame),
+      initialStocks.forEach(({ tickerCode }) => {
+        const cleanup = stompSubscribe(
+          `/topic/stocks/${tickerCode}/quote`,
+          (message) => {
+            const msg: StockItemMessage = JSON.parse(message.body);
+            const updated = parseStockItemMessage(msg);
+            setStocks((prev) =>
+              prev.map((item) =>
+                item.tickerCode === updated.tickerCode
+                  ? { ...item, ...updated }
+                  : item,
+              ),
+            );
+          },
+        );
+        cleanupFns.push(cleanup);
       });
-      client.activate();
     });
 
     return () => {
       cancelled = true;
-      client?.forceDisconnect();
+      cleanupFns.forEach((fn) => fn());
     };
   }, []);
 

--- a/src/pages/stocks/[stockId]/StockDetailPage.tsx
+++ b/src/pages/stocks/[stockId]/StockDetailPage.tsx
@@ -60,9 +60,8 @@ const STOCK_DETAIL_TOUR: TourStep[] = [
   },
 ];
 import { Loader2 } from "lucide-react";
-import { Client } from "@stomp/stompjs";
-import SockJS from "sockjs-client";
 import { useQueryClient } from "@tanstack/react-query";
+import { stompSubscribe } from "@/lib/stompClient";
 import {
   useStockQuoteQuery,
   useStockHoldingQuery,
@@ -112,51 +111,47 @@ export default function StockDetailPage() {
   const { data: tradeHistory } = useStockTradeHistoryQuery(stockCode);
   const { data: orderBook } = useOrderBookQuery(stockCode);
 
-  // ── 실시간 연결 (백엔드 스케줄러가 자동 구독 → STOMP 수신만 하면 됨) ────
+  // ── 실시간 구독 (공유 클라이언트 재사용) ────────────────────────────────
   useEffect(() => {
     if (!stockCode) return;
 
-    const wsUrl = (import.meta.env.VITE_API_BASE_URL ?? "") + "/ws";
-    const client = new Client({
-      webSocketFactory: () => new SockJS(wsUrl),
-      onConnect: () => {
-        console.log("[STOMP] 종목 상세 연결됨:", stockCode);
-        client.subscribe(`/topic/stocks/${stockCode}/quote`, (message) => {
-          const msg: StockItemMessage = JSON.parse(message.body);
-          queryClient.setQueryData<StockQuote>(
-            stockQueryKeys.quote(stockCode),
-            (prev) =>
-              prev
-                ? {
-                    ...prev,
-                    currentPrice: msg.currentPrice,
-                    changePrice: msg.changePrice,
-                    changeRate: msg.changeRate,
-                    highPrice: msg.highPrice,
-                    lowPrice: msg.lowPrice,
-                    volume: msg.volume,
-                  }
-                : prev,
-          );
-        });
-
-        client.subscribe(`/topic/orderbook/${stockCode}`, (message) => {
-          const raw = JSON.parse(message.body);
-          console.log("[STOMP] 호가 원본:", JSON.stringify(raw));
-          const msg: OrderBookData = raw.data ?? raw;
-          queryClient.setQueryData<OrderBookData>(
-            stockQueryKeys.orderBook(stockCode),
-            msg,
-          );
-        });
+    const unsubQuote = stompSubscribe(
+      `/topic/stocks/${stockCode}/quote`,
+      (message) => {
+        const msg: StockItemMessage = JSON.parse(message.body);
+        queryClient.setQueryData<StockQuote>(
+          stockQueryKeys.quote(stockCode),
+          (prev) =>
+            prev
+              ? {
+                  ...prev,
+                  currentPrice: msg.currentPrice,
+                  changePrice: msg.changePrice,
+                  changeRate: msg.changeRate,
+                  highPrice: msg.highPrice,
+                  lowPrice: msg.lowPrice,
+                  volume: msg.volume,
+                }
+              : prev,
+        );
       },
-      onDisconnect: () => console.log("[STOMP] 종목 상세 연결 끊김"),
-      onStompError: (frame) => console.error("[STOMP] 에러:", frame),
-    });
-    client.activate();
+    );
+
+    const unsubOrderBook = stompSubscribe(
+      `/topic/orderbook/${stockCode}`,
+      (message) => {
+        const raw = JSON.parse(message.body);
+        const msg: OrderBookData = raw.data ?? raw;
+        queryClient.setQueryData<OrderBookData>(
+          stockQueryKeys.orderBook(stockCode),
+          msg,
+        );
+      },
+    );
 
     return () => {
-      client.deactivate();
+      unsubQuote();
+      unsubOrderBook();
     };
   }, [stockCode, queryClient]);
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #103

## 💡 작업 배경
  Layout, StockList, StockDetailPage 각각에서 `new Client()`로 독립적인 WebSocket 연결을 생성하고 있어 페이지 이동 시마다 불필요한 SockJS 핸드셰이크 비용이 반복 발생하고 있다.
                                                                                                                
  - WebSocket 연결 횟수: 페이지마다 신규 연결 (총 3회)
  - 총 연결 비용: 약 302ms (Layout 18.9ms + StockList 268.5ms + StockDetail 14.6ms)    

## 🧩 작업 내용
앱 전체에서 하나의 STOMP 클라이언트를 공유하는 싱글톤 `src/lib/stompClient.ts` 구현

  - 개별 컴포넌트의 `new Client()` + `activate()` 제거 → `stompSubscribe()` 사용으로 통일                       
  - 페이지 이동 시 기존 연결을 재사용하고 구독만 추가/해제
  - 재연결 시 registry에 등록된 모든 구독 자동 복구                                                             
                  
  | | Before | After |                                                                                          
  |--|--|--|      
  | WebSocket 연결 횟수 | 3회 | 1회 |
  | StockList 진입 비용 | 268.5ms (신규 연결) | 0ms (연결 재사용) |                                             
  | StockDetail 진입 비용 | 14.6ms (신규 연결) | 0ms (연결 재사용) |
  | 총 연결 비용 | 약 302ms | 67.7ms |                                

## 📸 스크린샷(선택)
<img width="422" height="225" alt="Screenshot 2026-03-30 at 9 48 18 AM" src="https://github.com/user-attachments/assets/171a69bd-4ef0-4cc9-9045-d15f81b20afa" />


## 📝 기타