### PR TITLE
[Refactor]: 수익률 컬럼 구분: 총수익률, 종목 수익률

### DIFF
--- a/src/components/account/HoldingList.tsx
+++ b/src/components/account/HoldingList.tsx
@@ -71,7 +71,7 @@ export default function HoldingList({
               {showAvgPrice && <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>평균단가</th>}
               <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>현재가</th>
               <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>평가금액</th>
-              <th className={`text-right ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 font-medium`}>수익률</th>
+              <th className={`text-right ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 font-medium`}>종목 수익률</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -219,7 +219,7 @@ export default function SidebarNav() {
   }, [myProfile, updateUserProfile]);
 
   const returnRate = accountSummary
-    ? `${accountSummary.totalReturnRate >= 0 ? "+" : ""}${accountSummary.totalReturnRate.toFixed(1)}%`
+    ? `${accountSummary.totalReturnRate >= 0 ? "+" : ""}${accountSummary.totalReturnRate.toFixed(2)}%`
     : "-";
 
   const user = storeUser

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -95,9 +95,9 @@ export default function ProfileCard({
       {/* 수익률 / 총 수익 */}
       <div className="grid grid-cols-2 gap-2 pt-4 border-t border-gray-100 mb-4">
         <div className="text-center">
-          <p className="text-[12px] text-gray-400 mb-1">수익률</p>
+          <p className="text-[12px] text-gray-400 mb-1">총 수익률</p>
           <p className={`text-[13px] font-bold ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
-            {isPositive ? "+" : ""}{totalReturnRate.toFixed(1)}%
+            {isPositive ? "+" : ""}{totalReturnRate.toFixed(2)}%
           </p>
         </div>
         <div className="text-center">

--- a/src/components/stocks/HoldingStatus.tsx
+++ b/src/components/stocks/HoldingStatus.tsx
@@ -33,7 +33,7 @@ export default function HoldingStatus({ holding, cash, onBuy, onSell }: Props) {
                 colored: true,
               },
               {
-                label: "수익률",
+                label: "종목 수익률",
                 value: `${holding.profitRate >= 0 ? "+" : ""}${holding.profitRate.toFixed(2)}%`,
                 colored: true,
               },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -329,7 +329,7 @@ function HoldingsTable({
                   평가손익
                 </th>
                 <th className="text-right px-5 py-2.5 text-[12px] text-gray-400 font-medium">
-                  수익률
+                  종목 수익률
                 </th>
               </tr>
             </thead>
@@ -408,7 +408,7 @@ function InvestorReturnRate({ rate }: { rate: number | undefined }) {
   return (
     <span className={`text-[14px] font-semibold ${color}`}>
       {isPositive ? "+" : ""}
-      {rate.toFixed(1)}%
+      {rate.toFixed(2)}%
     </span>
   );
 }

--- a/src/pages/account/AccountPage.tsx
+++ b/src/pages/account/AccountPage.tsx
@@ -30,7 +30,7 @@ const ACCOUNT_TOUR: TourStep[] = [
   },
   {
     target: "account-return",
-    title: <span className="inline-flex items-center gap-1.5"><TrendingUp size={15} />수익률</span>,
+    title: <span className="inline-flex items-center gap-1.5"><TrendingUp size={15} />총 수익률</span>,
     description: "처음 받은 1,000만원 대비 지금까지 얼마나 벌었는지(%) 보여줘요. 빨강이면 수익, 파랑이면 손실이에요.",
     placement: "bottom",
   },
@@ -112,7 +112,7 @@ export default function AccountPage() {
 
         {/* 수익률 */}
         <div className="bg-white rounded-2xl border border-gray-100 px-6 py-5" data-tour="account-return">
-          <p className="text-[13px] text-gray-400 font-medium mb-2">수익률</p>
+          <p className="text-[13px] text-gray-400 font-medium mb-2">총 수익률</p>
           <p className={`text-[22px] font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
             {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(2)}%
           </p>

--- a/src/pages/mentee/MyMenteePage.tsx
+++ b/src/pages/mentee/MyMenteePage.tsx
@@ -116,7 +116,7 @@ function MenteeDetail({ menteeId }: { menteeId: number }) {
                   <TrendingUp size={12} className="text-gray-400" />
                   <span>총 수익률</span>
                   <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-                    {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(1)}%
+                    {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(2)}%
                   </span>
                 </div>
                 <div className="flex items-center gap-1">
@@ -193,7 +193,7 @@ function MenteeListItem({
       <div className="flex-1 min-w-0">
         <p className="text-[13px] font-semibold text-gray-900 truncate">{profile?.nickname ?? "..."}</p>
         <p className={`text-[12px] font-semibold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-          {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(1)}%
+          {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(2)}%
         </p>
       </div>
     </button>

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -188,7 +188,7 @@ export default function MyMentorPage() {
                   <TrendingUp size={12} className="text-gray-400" />
                   <span>총 수익률</span>
                   <span className={`font-bold ml-0.5 ${isPositive ? "text-red-500" : "text-blue-500"}`}>
-                    {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(1)}%
+                    {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(2)}%
                   </span>
                 </div>
                 <div className="flex items-center gap-1">

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -212,7 +212,7 @@ function ReturnCells({
   return (
     <>
       <td className={`px-4 py-3.5 text-[13px] font-medium text-right ${color}`}>
-        {prefix}{rate.toFixed(1)}%
+        {prefix}{rate.toFixed(2)}%
       </td>
       <td className={`px-4 py-3.5 text-[13px] font-medium text-right ${color}`}>
         {prefix}{(amount / 10000).toFixed(0)}만원


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #113 

## 💡 작업 배경
소수점 자릿수 통일 안되어 있었음. 
수익률 컬럼 이름 구분이 안됨.

## 🧩 작업 내용
소숫점 전부 둘째 자리로 보이게 통일
수익률 컬럼 이름 구분 -> 총 수익률, 종목 수익률

## 📸 스크린샷(선택)


## 📝 기타