### PR TITLE
[Refactor] 로그아웃 로직 통일

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -144,16 +144,21 @@ function NavItem({
 function UserProfile({
   user,
   onLogout,
+  onProfileClick,
 }: {
   user: NonNullable<SidebarNavProps["user"]>;
   onLogout?: () => void;
+  onProfileClick?: () => void;
 }) {
   const isPositive = user.returnRate.startsWith("+");
   const isNegative = user.returnRate.startsWith("-");
 
   return (
     <div className="px-4 pt-3 border-t border-gray-100 mt-2">
-      <div className="flex items-center gap-2.5 mb-2.5">
+      <button
+        onClick={onProfileClick}
+        className="flex items-center gap-2.5 mb-2.5 w-full text-left hover:opacity-80 transition-opacity cursor-pointer"
+      >
         <Avatar name={user.name} src={user.imageUrl || undefined} size={34} />
         <div className="min-w-0 flex-1">
           <p className="text-[14px] font-semibold text-gray-900 truncate">
@@ -172,7 +177,7 @@ function UserProfile({
             {user.returnRate}
           </p>
         </div>
-      </div>
+      </button>
 
       {onLogout && (
         <button
@@ -275,7 +280,13 @@ export default function SidebarNav() {
       </ul>
 
       <div className="flex-1" />
-      {user && <UserProfile user={user} onLogout={handleLogout} />}
+      {user && (
+        <UserProfile
+          user={user}
+          onLogout={handleLogout}
+          onProfileClick={() => navigate("/profile")}
+        />
+      )}
     </nav>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
@@ -23,6 +23,7 @@ import { authApi } from "@/api/authApi";
 import { useUnreadCountQuery } from "@/api/notificationApi";
 import { useMyProfileQuery } from "@/api/userListApi";
 import { useAccountSummaryQuery } from "@/api/accountSummaryApi";
+import LogoutModal from "@/components/profile/LogoutModal";
 
 export type NavItemConfig = {
   id: string;
@@ -155,29 +156,31 @@ function UserProfile({
 
   return (
     <div className="px-4 pt-3 border-t border-gray-100 mt-2">
-      <button
-        onClick={onProfileClick}
-        className="flex items-center gap-2.5 mb-2.5 w-full text-left hover:opacity-80 transition-opacity cursor-pointer"
-      >
-        <Avatar name={user.name} src={user.imageUrl || undefined} size={34} />
-        <div className="min-w-0 flex-1">
-          <p className="text-[14px] font-semibold text-gray-900 truncate">
-            {user.name}
-          </p>
-          <p
-            className={[
-              "text-[13px] font-medium mt-px",
-              isPositive
-                ? "text-red-500"
-                : isNegative
-                  ? "text-blue-500"
-                  : "text-gray-400",
-            ].join(" ")}
-          >
-            {user.returnRate}
-          </p>
+      <div className="flex items-center gap-2.5 mb-2.5">
+        <div
+          onClick={onProfileClick}
+          className="flex items-center gap-2.5 flex-1 min-w-0 cursor-pointer hover:opacity-80 transition-opacity"
+        >
+          <Avatar name={user.name} src={user.imageUrl || undefined} size={34} />
+          <div className="min-w-0 flex-1">
+            <p className="text-[14px] font-semibold text-gray-900 truncate">
+              {user.name}
+            </p>
+            <p
+              className={[
+                "text-[13px] font-medium mt-px",
+                isPositive
+                  ? "text-red-500"
+                  : isNegative
+                    ? "text-blue-500"
+                    : "text-gray-400",
+              ].join(" ")}
+            >
+              {user.returnRate}
+            </p>
+          </div>
         </div>
-      </button>
+      </div>
 
       {onLogout && (
         <button
@@ -212,6 +215,7 @@ export default function SidebarNav() {
   const { data: unreadCount } = useUnreadCountQuery();
   const { data: myProfile } = useMyProfileQuery();
   const { data: accountSummary } = useAccountSummaryQuery();
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
 
   // myProfile이 도착하면 sessionStorage에 동기화 → 다음 새로고침 시 깜빡임 방지
   useEffect(() => {
@@ -247,6 +251,11 @@ export default function SidebarNav() {
     }
   };
 
+  const handleLogoutConfirm = () => {
+    setShowLogoutModal(false);
+    handleLogout();
+  };
+
   const navItems = NAV_ITEMS.map((item) =>
     item.id === "notifications"
       ? { ...item, badge: unreadCount?.total ?? 0 }
@@ -254,6 +263,7 @@ export default function SidebarNav() {
   );
 
   return (
+    <>
     <nav className="w-64 h-screen sticky top-0 bg-white border-r border-gray-100 flex flex-col py-5 shrink-0 overflow-y-auto">
       <div className="px-4 pb-2">
         <button
@@ -283,10 +293,17 @@ export default function SidebarNav() {
       {user && (
         <UserProfile
           user={user}
-          onLogout={handleLogout}
+          onLogout={() => setShowLogoutModal(true)}
           onProfileClick={() => navigate("/profile")}
         />
       )}
     </nav>
+    {showLogoutModal && (
+      <LogoutModal
+        onClose={() => setShowLogoutModal(false)}
+        onConfirm={handleLogoutConfirm}
+      />
+    )}
+  </>
   );
 }

--- a/src/components/profile/LogoutModal.tsx
+++ b/src/components/profile/LogoutModal.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export default function LogoutModal({ onClose, onConfirm }: Props) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+    <div className="fixed inset-0 z-[999] flex items-center justify-center bg-black/40" onClick={onClose}>
       <div className="bg-white rounded-2xl w-[360px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
         {/* 헤더 */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #105

## 💡 작업 배경
사이드바탭에서의 로그아웃은 모달창은 안나타내고 있어 내 프로필과 통일성이 깨지고 있다.

## 🧩 작업 내용
- 사이드바텝에서 로그아웃시 모달창 나타내기
- 사이드바 하단 프로필 클릭시 내 프로필로 이동

## 📸 스크린샷(선택)
<img width="1509" height="825" alt="image" src="https://github.com/user-attachments/assets/11b72391-c85b-4215-b558-7ce1be5589e9" />


## 📝 기타