### PR TITLE
[Refactor] useSearchParams을 이용한 상태 유지

### DIFF
--- a/src/components/account/HoldingList.tsx
+++ b/src/components/account/HoldingList.tsx
@@ -65,23 +65,13 @@ export default function HoldingList({
       <div className="overflow-y-auto flex-1">
         <table className="w-full">
           <thead className="sticky top-0 z-10">
-<<<<<<< HEAD
-            <tr className="bg-gray-50 border-b border-gray-100">
-              <th className={`text-left ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 font-medium`}>종목</th>
-              <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>수량</th>
-              {showAvgPrice && <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>평균단가</th>}
-              <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>현재가</th>
-              <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 font-medium`}>평가금액</th>
-              <th className={`text-right ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 font-medium`}>종목 수익률</th>
-=======
             <tr className="bg-gray-50 dark:bg-slate-800 border-b border-gray-100 dark:border-slate-700">
               <th className={`text-left ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 dark:text-slate-500 font-medium`}>종목</th>
               <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 dark:text-slate-500 font-medium`}>수량</th>
               {showAvgPrice && <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 dark:text-slate-500 font-medium`}>평균단가</th>}
               <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 dark:text-slate-500 font-medium`}>현재가</th>
               <th className={`text-right ${compact ? "px-2 py-2" : "px-4 py-3"} text-[11px] text-gray-400 dark:text-slate-500 font-medium`}>평가금액</th>
-              <th className={`text-right ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 dark:text-slate-500 font-medium`}>수익률</th>
->>>>>>> 3565c14 (feat: 다크모드 구현)
+              <th className={`text-right ${compact ? "px-3 py-2" : "px-6 py-3"} text-[11px] text-gray-400 dark:text-slate-500 font-medium`}>종목 수익률</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50 dark:divide-slate-800">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -161,14 +161,13 @@ function UserProfile({
   return (
     <div className="px-4 pt-3 border-t border-gray-100 mt-2 dark:border-slate-800">
       <div className="flex items-center gap-2.5 mb-2.5">
-<<<<<<< HEAD
         <div
           onClick={onProfileClick}
           className="flex items-center gap-2.5 flex-1 min-w-0 cursor-pointer hover:opacity-80 transition-opacity"
         >
           <Avatar name={user.name} src={user.imageUrl || undefined} size={34} />
           <div className="min-w-0 flex-1">
-            <p className="text-[14px] font-semibold text-gray-900 truncate">
+            <p className="text-[14px] font-semibold text-gray-900 dark:text-gray-100 truncate">
               {user.name}
             </p>
             <p
@@ -184,25 +183,6 @@ function UserProfile({
               {user.returnRate}
             </p>
           </div>
-=======
-        <Avatar name={user.name} src={user.imageUrl || undefined} size={34} />
-        <div className="min-w-0 flex-1">
-          <p className="text-[14px] font-semibold text-gray-900 truncate dark:text-gray-100">
-            {user.name}
-          </p>
-          <p
-            className={[
-              "text-[13px] font-medium mt-px",
-              isPositive
-                ? "text-red-500"
-                : isNegative
-                  ? "text-blue-500"
-                  : "text-gray-400",
-            ].join(" ")}
-          >
-            {user.returnRate}
-          </p>
->>>>>>> 3565c14 (feat: 다크모드 구현)
         </div>
         <button
           onClick={toggleTheme}
@@ -309,12 +289,8 @@ export default function SidebarNav() {
   );
 
   return (
-<<<<<<< HEAD
     <>
-    <nav className="w-64 h-screen sticky top-0 bg-white border-r border-gray-100 flex flex-col py-5 shrink-0 overflow-y-auto">
-=======
     <nav className="w-64 h-screen sticky top-0 bg-white border-r border-gray-100 flex flex-col py-5 shrink-0 overflow-y-auto dark:bg-slate-900 dark:border-slate-800">
->>>>>>> 3565c14 (feat: 다크모드 구현)
       <div className="px-4 pb-2">
         <button
           onClick={() => navigate("/")}

--- a/src/components/profile/LogoutModal.tsx
+++ b/src/components/profile/LogoutModal.tsx
@@ -8,13 +8,8 @@ type Props = {
 
 export default function LogoutModal({ onClose, onConfirm }: Props) {
   return (
-<<<<<<< HEAD
     <div className="fixed inset-0 z-[999] flex items-center justify-center bg-black/40" onClick={onClose}>
-      <div className="bg-white rounded-2xl w-[360px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
-=======
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
       <div className="bg-white dark:bg-slate-900 rounded-2xl w-90 shadow-2xl" onClick={(e) => e.stopPropagation()}>
->>>>>>> 3565c14 (feat: 다크모드 구현)
         {/* 헤더 */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-slate-800">
           <p className="text-[15px] font-bold text-gray-900 dark:text-gray-100">로그아웃</p>

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -95,11 +95,7 @@ export default function ProfileCard({
       {/* 수익률 / 총 수익 */}
       <div className="grid grid-cols-2 gap-2 pt-4 border-t border-gray-100 dark:border-slate-800 mb-4">
         <div className="text-center">
-<<<<<<< HEAD
-          <p className="text-[12px] text-gray-400 mb-1">총 수익률</p>
-=======
-          <p className="text-[12px] text-gray-400 dark:text-slate-500 mb-1">수익률</p>
->>>>>>> 3565c14 (feat: 다크모드 구현)
+          <p className="text-[12px] text-gray-400 dark:text-slate-500 mb-1">총 수익률</p>
           <p className={`text-[13px] font-bold ${isPositive ? "text-[#FF4444]" : "text-[#0046FF]"}`}>
             {isPositive ? "+" : ""}{totalReturnRate.toFixed(2)}%
           </p>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -328,13 +328,8 @@ function HoldingsTable({
                 <th className="text-right px-4 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium">
                   평가손익
                 </th>
-<<<<<<< HEAD
-                <th className="text-right px-5 py-2.5 text-[12px] text-gray-400 font-medium">
-                  종목 수익률
-=======
                 <th className="text-right px-5 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium">
-                  수익률
->>>>>>> 3565c14 (feat: 다크모드 구현)
+                  종목 수익률
                 </th>
               </tr>
             </thead>

--- a/src/pages/account/AccountPage.tsx
+++ b/src/pages/account/AccountPage.tsx
@@ -111,13 +111,8 @@ export default function AccountPage() {
         </div>
 
         {/* 수익률 */}
-<<<<<<< HEAD
-        <div className="bg-white rounded-2xl border border-gray-100 px-6 py-5" data-tour="account-return">
-          <p className="text-[13px] text-gray-400 font-medium mb-2">총 수익률</p>
-=======
         <div className="bg-white dark:bg-slate-900 rounded-2xl border border-gray-100 dark:border-slate-800 px-6 py-5" data-tour="account-return">
-          <p className="text-[13px] text-gray-400 font-medium mb-2">수익률</p>
->>>>>>> 3565c14 (feat: 다크모드 구현)
+          <p className="text-[13px] text-gray-400 font-medium mb-2">총 수익률</p>
           <p className={`text-[22px] font-bold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
             {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(2)}%
           </p>

--- a/src/pages/guide/GuidePage.tsx
+++ b/src/pages/guide/GuidePage.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   BookOpen,
   TrendingUp,
@@ -271,9 +272,27 @@ const NAV_HEIGHT = 49; // py-3.5(28px) + 텍스트(21px)
 
 // ─── 컴포넌트 ────────────────────────────────────────────────
 export default function GuidePage() {
-  const [activeSection, setActiveSection] = useState<SectionId>("intro");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [activeSection, setActiveSection] = useState<SectionId>(
+    (searchParams.get("section") as SectionId) ?? "intro"
+  );
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
   const contentRef = useRef<HTMLDivElement>(null);
+
+  // 초기 마운트 시 URL 섹션으로 스크롤
+  useEffect(() => {
+    const section = searchParams.get("section") as SectionId | null;
+    if (!section || section === "intro") return;
+    // refs가 채워질 때까지 약간 지연
+    const timer = setTimeout(() => {
+      const el = sectionRefs.current[section];
+      const container = contentRef.current;
+      if (!el || !container) return;
+      container.scrollTo({ top: el.offsetTop - NAV_HEIGHT - 24, behavior: "smooth" });
+    }, 50);
+    return () => clearTimeout(timer);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // 스크롤 감지 → 활성 섹션 업데이트
   useEffect(() => {
@@ -294,11 +313,15 @@ export default function GuidePage() {
         }
       }
       setActiveSection(current);
+      setSearchParams(
+        (p) => { if (current === "intro") p.delete("section"); else p.set("section", current); return p; },
+        { replace: true }
+      );
     };
 
     container.addEventListener("scroll", handleScroll, { passive: true });
     return () => container.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [setSearchParams]);
 
   const scrollTo = (id: SectionId) => {
     const el = sectionRefs.current[id];

--- a/src/pages/mentee/MyMenteePage.tsx
+++ b/src/pages/mentee/MyMenteePage.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { Users, TrendingUp, Loader2, ClipboardList } from "lucide-react";
 import SpotlightTour from "@/components/onboarding/SpotlightTour";
 import type { TourStep } from "@/components/onboarding/SpotlightTour";
@@ -62,7 +61,10 @@ function fmtAmount(n: number) {
 
 function MenteeDetail({ menteeId }: { menteeId: number }) {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<TabId>("portfolio");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = (searchParams.get("tab") ?? "portfolio") as TabId;
+  const setActiveTab = (v: TabId) =>
+    setSearchParams((p) => { if (v === "portfolio") p.delete("tab"); else p.set("tab", v); return p; }, { replace: true });
 
   const { data: mentee, isLoading } = useUserProfileQuery(menteeId);
   const { data: summary } = useAccountSummaryByUserQuery(menteeId);
@@ -205,7 +207,10 @@ function MenteeListItem({
 export default function MyMenteePage() {
   const { data: menteesData, isLoading } = useMyMenteesQuery();
   const mentees = menteesData?.mentees ?? [];
-  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedId = searchParams.get("mentee") ? Number(searchParams.get("mentee")) : null;
+  const setSelectedId = (id: number) =>
+    setSearchParams((p) => { p.set("mentee", String(id)); return p; }, { replace: true });
 
   const activeMenteeId = selectedId ?? mentees[0]?.userId ?? null;
 

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { Users, TrendingUp, Loader2, X, GraduationCap, BookOpen } from "lucide-react";
 import SpotlightTour from "@/components/onboarding/SpotlightTour";
 import type { TourStep } from "@/components/onboarding/SpotlightTour";
@@ -83,7 +83,10 @@ function CancelMentorModal({ mentorNickname, onClose, onConfirm }: { mentorNickn
 export default function MyMentorPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState<TabId>("portfolio");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = (searchParams.get("tab") ?? "portfolio") as TabId;
+  const setActiveTab = (v: TabId) =>
+    setSearchParams((p) => { if (v === "portfolio") p.delete("tab"); else p.set("tab", v); return p; }, { replace: true });
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
 

--- a/src/pages/notification/NotificationPage.tsx
+++ b/src/pages/notification/NotificationPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
 import { Bell } from "lucide-react";
+import { useSearchParams } from "react-router-dom";
 import {
   useNotificationsQuery,
   useUnreadCountQuery,
@@ -20,7 +20,10 @@ const TABS: { id: TabId; label: string; countKey?: keyof { total: number; social
 ];
 
 export default function NotificationPage() {
-  const [activeTab, setActiveTab] = useState<TabId>("all");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = (searchParams.get("tab") ?? "all") as TabId;
+  const setActiveTab = (v: TabId) =>
+    setSearchParams((p) => { if (v === "all") p.delete("tab"); else p.set("tab", v); return p; }, { replace: true });
 
   const { data: notifications = [] } = useNotificationsQuery();
   const { data: unreadCount } = useUnreadCountQuery();

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { User, FolderOpen } from "lucide-react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import SpotlightTour from "@/components/onboarding/SpotlightTour";
 import type { TourStep } from "@/components/onboarding/SpotlightTour";
 import { useQueryClient } from "@tanstack/react-query";
@@ -58,8 +58,10 @@ export default function ProfilePage() {
   const user = useUser();
   const clearAuth = useAuthStore((s) => s.clearAuth);
   const location = useLocation();
-  const initialTab = (location.state as { tab?: TabId } | null)?.tab ?? "diary";
-  const [activeTab, setActiveTab] = useState<TabId>(initialTab);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = (searchParams.get("tab") ?? (location.state as { tab?: TabId } | null)?.tab ?? "diary") as TabId;
+  const setActiveTab = (v: TabId) =>
+    setSearchParams((p) => { if (v === "diary") p.delete("tab"); else p.set("tab", v); return p; }, { replace: true });
   const [followModal, setFollowModal] = useState<
     "followers" | "following" | null
   >("following");

--- a/src/pages/stocks/StockList.tsx
+++ b/src/pages/stocks/StockList.tsx
@@ -319,26 +319,13 @@ export default function StockList() {
               className={`px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-colors ${
                 isActive
                   ? "bg-[#0046FF] text-white"
-                  : "bg-white border border-gray-200 text-gray-500 hover:border-gray-300"
+                  : "bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 text-gray-500 dark:text-slate-400 hover:border-gray-300 dark:hover:border-slate-600"
               }`}
             >
               {s}
             </button>
           );
         })}
-        {SECTORS.map((s) => (
-          <button
-            key={s}
-            onClick={() => setSector(s)}
-            className={`px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-colors ${
-              sector === s
-                ? "bg-[#0046FF] text-white"
-                : "bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 text-gray-500 dark:text-slate-400 hover:border-gray-300 dark:hover:border-slate-600"
-            }`}
-          >
-            {s}
-          </button>
-        ))}
       </div>
 
       <SpotlightTour tourKey="invest" steps={INVEST_TOUR} />

--- a/src/pages/stocks/StockList.tsx
+++ b/src/pages/stocks/StockList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import SpotlightTour from "@/components/onboarding/SpotlightTour";
 import type { TourStep } from "@/components/onboarding/SpotlightTour";
 
@@ -195,9 +195,17 @@ export default function StockList() {
     useMarketIndicesQuery();
 
   const [stocks, setStocks] = useState<StockItem[]>([]);
-  const [search, setSearch] = useState("");
-  const [sector, setSector] = useState("전체");
-  const [sort, setSort] = useState<SortType>("거래량순");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const search = searchParams.get("search") ?? "";
+  const sector = searchParams.get("sector") ?? "전체";
+  const sort = (searchParams.get("sort") ?? "거래량순") as SortType;
+
+  const setSearch = (v: string) =>
+    setSearchParams((p) => { if (v) p.set("search", v); else p.delete("search"); return p; }, { replace: true });
+  const setSector = (v: string) =>
+    setSearchParams((p) => { if (v === "전체") p.delete("sector"); else p.set("sector", v); return p; }, { replace: true });
+  const setSort = (v: SortType) =>
+    setSearchParams((p) => { if (v === "거래량순") p.delete("sort"); else p.set("sort", v); return p; }, { replace: true });
 
   // ── 초기 fetch 후 STOMP 구독 (공유 클라이언트 재사용) ────────────────────
   useEffect(() => {

--- a/src/pages/stocks/StockList.tsx
+++ b/src/pages/stocks/StockList.tsx
@@ -197,13 +197,19 @@ export default function StockList() {
   const [stocks, setStocks] = useState<StockItem[]>([]);
   const [searchParams, setSearchParams] = useSearchParams();
   const search = searchParams.get("search") ?? "";
-  const sector = searchParams.get("sector") ?? "전체";
+  const sectors = (searchParams.get("sector") ?? "").split(",").filter(Boolean);
   const sort = (searchParams.get("sort") ?? "거래량순") as SortType;
 
   const setSearch = (v: string) =>
     setSearchParams((p) => { if (v) p.set("search", v); else p.delete("search"); return p; }, { replace: true });
-  const setSector = (v: string) =>
-    setSearchParams((p) => { if (v === "전체") p.delete("sector"); else p.set("sector", v); return p; }, { replace: true });
+  const toggleSector = (v: string) =>
+    setSearchParams((p) => {
+      if (v === "전체") { p.delete("sector"); return p; }
+      const cur = (p.get("sector") ?? "").split(",").filter(Boolean);
+      const next = cur.includes(v) ? cur.filter((s) => s !== v) : [...cur, v];
+      if (next.length === 0) p.delete("sector"); else p.set("sector", next.join(","));
+      return p;
+    }, { replace: true });
   const setSort = (v: SortType) =>
     setSearchParams((p) => { if (v === "거래량순") p.delete("sort"); else p.set("sort", v); return p; }, { replace: true });
 
@@ -242,7 +248,7 @@ export default function StockList() {
   }, []);
 
   const filtered = stocks
-    .filter((s) => sector === "전체" || SECTOR_MAP[s.sectorType] === sector)
+    .filter((s) => sectors.length === 0 || sectors.includes(SECTOR_MAP[s.sectorType]))
     .filter(
       (s) =>
         s.stockName.toLowerCase().includes(search.toLowerCase()) ||
@@ -305,19 +311,22 @@ export default function StockList() {
 
       {/* 섹터 탭 */}
       <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
-        {SECTORS.map((s) => (
-          <button
-            key={s}
-            onClick={() => setSector(s)}
-            className={`px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-colors ${
-              sector === s
-                ? "bg-[#0046FF] text-white"
-                : "bg-white border border-gray-200 text-gray-500 hover:border-gray-300"
-            }`}
-          >
-            {s}
-          </button>
-        ))}
+        {SECTORS.map((s) => {
+          const isActive = s === "전체" ? sectors.length === 0 : sectors.includes(s);
+          return (
+            <button
+              key={s}
+              onClick={() => toggleSector(s)}
+              className={`px-3.5 py-1.5 rounded-full text-[13px] font-medium whitespace-nowrap transition-colors ${
+                isActive
+                  ? "bg-[#0046FF] text-white"
+                  : "bg-white border border-gray-200 text-gray-500 hover:border-gray-300"
+              }`}
+            >
+              {s}
+            </button>
+          );
+        })}
       </div>
 
       <SpotlightTour tourKey="invest" steps={INVEST_TOUR} />

--- a/src/pages/trade-diaries/TradeDiaryPage.tsx
+++ b/src/pages/trade-diaries/TradeDiaryPage.tsx
@@ -1,7 +1,6 @@
 import { useMyDiariesQuery } from "@/api/tradeDiaryApi";
 import { Search, PenLine } from "lucide-react";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import type { MyDiariesItem } from "@/api/tradeDiaryApi";
 import SpotlightTour from "@/components/onboarding/SpotlightTour";
 import type { TourStep } from "@/components/onboarding/SpotlightTour";
@@ -120,7 +119,10 @@ function DiaryCard({
 
 export default function TradeDiaryPage() {
   const navigate = useNavigate();
-  const [search, setSearch] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const search = searchParams.get("search") ?? "";
+  const setSearch = (v: string) =>
+    setSearchParams((p) => { v ? p.set("search", v) : p.delete("search"); return p; }, { replace: true });
   const { data: myDiaries = [], isLoading } = useMyDiariesQuery();
   const { data: stocks = [] } = useStocksQuery();
   const logoMap = new Map(stocks.map((s) => [s.stockName, s.stockLogo]));

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import SpotlightTour from "@/components/onboarding/SpotlightTour";
 import type { TourStep } from "@/components/onboarding/SpotlightTour";
 
@@ -254,9 +253,17 @@ function UserRow({
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function UserListPage() {
-  const [tab, setTab] = useState<"전체" | "팔로잉">("전체");
-  const [search, setSearch] = useState("");
-  const [sortBy, setSortBy] = useState<SortBy>("returnRate");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = (searchParams.get("tab") ?? "전체") as "전체" | "팔로잉";
+  const search = searchParams.get("search") ?? "";
+  const sortBy = (searchParams.get("sort") ?? "returnRate") as SortBy;
+
+  const setTab = (v: "전체" | "팔로잉") =>
+    setSearchParams((p) => { v === "전체" ? p.delete("tab") : p.set("tab", v); return p; }, { replace: true });
+  const setSearch = (v: string) =>
+    setSearchParams((p) => { v ? p.set("search", v) : p.delete("search"); return p; }, { replace: true });
+  const setSortBy = (v: SortBy) =>
+    setSearchParams((p) => { v === "returnRate" ? p.delete("sort") : p.set("sort", v); return p; }, { replace: true });
 
   const { data, isLoading } = useUserListQuery();
   const { toggleFollow, setMentoringStatus } = useUserListCacheUpdate();


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #115 

## 💡 작업 배경
새로고침을 하면 탭들이 유지가 되지 않는다.


## 🧩 작업 내용       
  - **URL 상태 관리**: 탭·검색·정렬·섹터 필터를 `useSearchParams`로 URL에 저장, 새로고침 시 상태 유지
    - 적용 페이지: 주식 목록, 알림, 내 프로필, 나의 멘토, 나의 멘티, 매매일지, 유저 목록, 가이드                
  - **섹터 다중 선택**: StockList에서 섹터 여러 개 동시 선택 가능 (URL: `?sector=금융,건설`)                         

## 📸 스크린샷(선택)


## 📝 기타