### PR TITLE
[Feat] WebSocket 실시간 연동 (거래내역 + 알림)

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -15,6 +15,7 @@ export interface LoginRequest {
 }
 
 export interface LoginData {
+  userId: number;
   nickname: string;
   accessToken: string;
   refreshToken: string;
@@ -65,5 +66,5 @@ export const authApi = {
 
   /** GET /api/users/me — 내 정보 조회 */
   getMe: () =>
-    fetchClient.get<ApiResponse<{ nickname: string; provider: "EMAIL" | "GOOGLE" }>>("/api/users/me"),
+    fetchClient.get<ApiResponse<{ userId: number; nickname: string; provider: "EMAIL" | "GOOGLE" }>>("/api/users/me"),
 };

--- a/src/api/notificationApi.ts
+++ b/src/api/notificationApi.ts
@@ -1,6 +1,8 @@
+import { useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { fetchClient } from "@/lib/fetchClient";
 import type { ApiResponse } from "./authApi";
+import { stompSubscribe } from "@/lib/stompClient";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -84,6 +86,38 @@ export function useAcceptMentorMutation() {
       queryClient.invalidateQueries({ queryKey: notificationQueryKeys.unreadCount });
     },
   });
+}
+
+export function useNotificationSubscription(userId: number | undefined) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const unsub = stompSubscribe(`/topic/notifications/${userId}`, (message) => {
+      const item: NotificationItem = JSON.parse(message.body);
+
+      queryClient.setQueryData<NotificationItem[]>(
+        notificationQueryKeys.list,
+        (prev) => (prev ? [item, ...prev] : [item]),
+      );
+
+      queryClient.setQueryData<NotificationCountResponse>(
+        notificationQueryKeys.unreadCount,
+        (prev) => {
+          if (!prev) return prev;
+          const categoryKey = item.category.toLowerCase() as keyof Omit<NotificationCountResponse, "total">;
+          return {
+            ...prev,
+            total: prev.total + 1,
+            [categoryKey]: prev[categoryKey] + 1,
+          };
+        },
+      );
+    });
+
+    return unsub;
+  }, [userId, queryClient]);
 }
 
 export function useRejectMentorMutation() {

--- a/src/api/stockApi.ts
+++ b/src/api/stockApi.ts
@@ -131,31 +131,6 @@ export type TradeOrderResponse = {
   status: string;
 };
 
-const SIDE_LABEL: Record<string, string> = { BUY: "매수", SELL: "매도" };
-const ORDER_TYPE_LABEL: Record<string, string> = { MARKET: "시장가", LIMIT: "지정가" };
-const STATUS_LABEL: Record<string, string> = {
-  PENDING: "대기",
-  FILLED: "체결",
-  CANCELLED: "취소",
-};
-
-export function mapTradeOrderResponseToStockTradeOrder(
-  res: TradeOrderResponse,
-): StockTradeOrder {
-  return {
-    orderId: res.orderId,
-    side: res.tradeType as "BUY" | "SELL",
-    sideLabel: SIDE_LABEL[res.tradeType] ?? res.tradeType,
-    orderType: res.orderType as "MARKET" | "LIMIT",
-    orderTypeLabel: ORDER_TYPE_LABEL[res.orderType] ?? res.orderType,
-    orderPrice: res.price,
-    quantity: res.quantity,
-    orderAmount: res.price * res.quantity,
-    status: res.status,
-    statusLabel: STATUS_LABEL[res.status] ?? res.status,
-    cancelable: res.status === "PENDING",
-  };
-}
 
 // ─── Types: 캔들 데이터 ───────────────────────────────────────────────────────
 

--- a/src/api/stockApi.ts
+++ b/src/api/stockApi.ts
@@ -131,6 +131,32 @@ export type TradeOrderResponse = {
   status: string;
 };
 
+const SIDE_LABEL: Record<string, string> = { BUY: "매수", SELL: "매도" };
+const ORDER_TYPE_LABEL: Record<string, string> = { MARKET: "시장가", LIMIT: "지정가" };
+const STATUS_LABEL: Record<string, string> = {
+  PENDING: "대기",
+  FILLED: "체결",
+  CANCELLED: "취소",
+};
+
+export function mapTradeOrderResponseToStockTradeOrder(
+  res: TradeOrderResponse,
+): StockTradeOrder {
+  return {
+    orderId: res.orderId,
+    side: res.tradeType as "BUY" | "SELL",
+    sideLabel: SIDE_LABEL[res.tradeType] ?? res.tradeType,
+    orderType: res.orderType as "MARKET" | "LIMIT",
+    orderTypeLabel: ORDER_TYPE_LABEL[res.orderType] ?? res.orderType,
+    orderPrice: res.price,
+    quantity: res.quantity,
+    orderAmount: res.price * res.quantity,
+    status: res.status,
+    statusLabel: STATUS_LABEL[res.status] ?? res.status,
+    cancelable: res.status === "PENDING",
+  };
+}
+
 // ─── Types: 캔들 데이터 ───────────────────────────────────────────────────────
 
 export type CandleData = {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,7 +11,8 @@ import type { MarketIndexData, MarketIndicatorMessage } from "@/api/homeApi";
 import Sidebar from "./Sidebar";
 import OnboardingOverlay from "@/components/onboarding/OnboardingOverlay";
 import { useOnboardingStore } from "@/store/onboardingStore";
-import { useAuthStore } from "@/store/authStore";
+import { useAuthStore, useUser } from "@/store/authStore";
+import { useNotificationSubscription } from "@/api/notificationApi";
 
 function parseJwtSub(token: string): string | null {
   try {
@@ -27,6 +28,9 @@ export default function Layout() {
   const accessToken = useAuthStore((s) => s.accessToken);
   const hasSeenOnboarding = useOnboardingStore((s) => s.hasSeenOnboarding);
   const init = useOnboardingStore((s) => s.init);
+  const user = useUser();
+
+  useNotificationSubscription(user?.userId);
 
   // JWT sub(userId)를 키로 유저별 온보딩 상태 불러오기
   useEffect(() => {

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -86,6 +86,7 @@ export default function LoginPage() {
             useAuthStore.getState().setAccessToken(newToken);
             const userRes = await authApi.getMe();
             setAuth(newToken, {
+              userId: userRes.data.userId,
               nickname: userRes.data.nickname,
               provider: userRes.data.provider,
             });
@@ -121,6 +122,7 @@ export default function LoginPage() {
       }
 
       setAuth(res.data.accessToken, {
+        userId: res.data.userId,
         nickname: res.data.nickname,
         provider: "EMAIL",
       });

--- a/src/pages/auth/OauthCallbackPage.tsx
+++ b/src/pages/auth/OauthCallbackPage.tsx
@@ -26,7 +26,7 @@ export default function OAuthCallbackPage() {
       .googleCallback(code)
       .then((res) => {
         console.log("[OAuth] 응답:", res);
-        setAuth(res.data.accessToken, { nickname: res.data.nickname, provider: "GOOGLE" });
+        setAuth(res.data.accessToken, { userId: res.data.userId, nickname: res.data.nickname, provider: "GOOGLE" });
         navigate("/", { replace: true });
       })
       .catch((err) => {

--- a/src/pages/stocks/[stockId]/StockDetailPage.tsx
+++ b/src/pages/stocks/[stockId]/StockDetailPage.tsx
@@ -76,7 +76,10 @@ import type {
   StockQuote,
   StockItemMessage,
   OrderBookData,
+  StockTradeOrder,
+  StockTradeHistory,
 } from "@/api/stockApi";
+import { useUser } from "@/store/authStore";
 
 import StockDetailHeader from "@/components/stocks/StockDetailHeader";
 import StockInfoGrid from "@/components/stocks/StockInfoGrid";
@@ -100,6 +103,7 @@ export default function StockDetailPage() {
   const { stockCode = "" } = useParams<{ stockCode: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const user = useUser();
   const [orderSide, setOrderSide] = useState<OrderSide | null>(null);
   const [selectedPrice, setSelectedPrice] = useState<number | null>(null);
   const [pendingOrder, setPendingOrder] = useState<PendingOrder | null>(null);
@@ -150,6 +154,25 @@ export default function StockDetailPage() {
             msg,
           );
         });
+
+        if (user?.userId) {
+          client.subscribe(`/topic/trades/${user.userId}`, (message) => {
+            const order: StockTradeOrder = JSON.parse(message.body);
+            queryClient.setQueryData<StockTradeHistory>(
+              stockQueryKeys.tradeHistory(stockCode),
+              (prev) => {
+                if (!prev) return prev;
+                const exists = prev.orders.some((o) => o.orderId === order.orderId);
+                return {
+                  ...prev,
+                  orders: exists
+                    ? prev.orders.map((o) => o.orderId === order.orderId ? order : o)
+                    : [order, ...prev.orders],
+                };
+              },
+            );
+          });
+        }
       },
       onDisconnect: () => console.log("[STOMP] 종목 상세 연결 끊김"),
       onStompError: (frame) => console.error("[STOMP] 에러:", frame),
@@ -159,7 +182,7 @@ export default function StockDetailPage() {
     return () => {
       client.deactivate();
     };
-  }, [stockCode, queryClient]);
+  }, [stockCode, queryClient, user?.userId]);
 
   // ── 브라우저 탭 제목 실시간 업데이트 ────────────────────────────────────
   useEffect(() => {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from "zustand/middleware";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 export interface AuthUser {
+  userId: number;
   nickname: string;
   imageUrl?: string;
   provider?: "EMAIL" | "GOOGLE";


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #127 

## 💡 작업 배경
기존에는 거래내역과 알림 모두 REST API로만 조회해서 새로고침하거나 직접 페이지에 들어가야 데이터가 갱신됐음. 주문 체결, 멘토 신청 등 실시간으로 반영되어야 하는 데이터들이 즉시 업데이트되지 않는 문제가 있었음

## 🧩 작업 내용
  - authApi.ts / authStore.ts — 로그인 응답에 userId 추가, AuthUser 타입에 반영
  - LoginPage.tsx / OauthCallbackPage.tsx — setAuth 호출 시 userId 저장
  - StockDetailPage.tsx — 페이지 진입 시 /topic/trades/{userId} 구독, 메시지 수신 시 orderId     
  기준으로 기존 주문이면 상태 업데이트 / 없으면 목록 상단에 추가
  - notificationApi.ts — /topic/notifications/{userId} 구독 훅(useNotificationSubscription) 추가,
   수신 시 알림 목록 상단 추가 + unreadCount 캐시 +1
  - Layout.tsx — useNotificationSubscription 연결, 로그인 후 전 페이지에서 알림 실시간 수신 
  