### PR TITLE
[Refactor] 주문/멘토링 취소 확인 모달 추가 및 팔로잉·멘티 목록 UX 개선

### DIFF
--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -24,6 +24,10 @@ type Props = {
   isFollowing?: boolean;
   onFollowClick?: () => void;
   badge?: "멘토" | "멘티";
+  mentoringStatus?: "NONE" | "PENDING" | "ACCEPTED";
+  hasAcceptedMentor?: boolean;
+  onMentoringRequest?: () => void;
+  onMentoringCancel?: () => void;
 };
 
 function fmtAmount(n: number) {
@@ -49,6 +53,10 @@ export default function ProfileCard({
   isFollowing,
   onFollowClick,
   badge,
+  mentoringStatus,
+  hasAcceptedMentor,
+  onMentoringRequest,
+  onMentoringCancel,
 }: Props) {
   const isPositive = totalReturnRate >= 0;
 
@@ -156,13 +164,40 @@ export default function ProfileCard({
             </Button> */}
           </>
         ) : (
-          <Button
-            variant={isFollowing ? "invalid" : "primary"}
-            className="w-full"
-            onClick={onFollowClick}
-          >
-            {isFollowing ? "팔로잉" : "팔로우"}
-          </Button>
+          <>
+            <Button
+              variant={isFollowing ? "basic" : "primary"}
+              className="w-full"
+              onClick={onFollowClick}
+            >
+              {isFollowing ? "팔로잉" : "팔로우"}
+            </Button>
+            {mentoringStatus === "ACCEPTED" && (
+              <button
+                onClick={onMentoringCancel}
+                className="w-full py-1.5 rounded-[10px] text-white bg-orange-400 hover:bg-orange-500 transition-colors"
+              >
+                멘토취소
+              </button>
+            )}
+            {mentoringStatus === "PENDING" && (
+              <button
+                disabled
+                className="w-full py-1.5 rounded-[10px] border border-orange-400 text-orange-400 bg-white dark:bg-slate-900 opacity-60 cursor-default"
+              >
+                신청완료
+              </button>
+            )}
+            {mentoringStatus === "NONE" && (
+              <button
+                disabled={hasAcceptedMentor}
+                onClick={onMentoringRequest}
+                className={`w-full py-1.5 rounded-[10px] text-white bg-orange-400 transition-colors ${hasAcceptedMentor ? "opacity-40 cursor-default" : "hover:bg-orange-500"}`}
+              >
+                멘토신청
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/components/stocks/TradeHistory.tsx
+++ b/src/components/stocks/TradeHistory.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
+import { X } from "lucide-react";
 import type { StockTradeOrder } from "@/api/stockApi";
 import { useCancelOrderMutation } from "@/api/stockApi";
+import Button from "@/components/ui/Button";
 
 function formatAmount(amount: number): string {
   if (amount >= 100_000_000) return `${(amount / 100_000_000).toFixed(1)}억원`;
@@ -14,8 +17,17 @@ interface Props {
 
 export default function TradeHistory({ tickerCode, orders }: Props) {
   const { mutate: cancelOrder, isPending } = useCancelOrderMutation(tickerCode);
+  const [confirmOrderId, setConfirmOrderId] = useState<number | null>(null);
+
+  function handleCancelConfirm() {
+    if (confirmOrderId !== null) {
+      cancelOrder(confirmOrderId);
+      setConfirmOrderId(null);
+    }
+  }
 
   return (
+    <>
     <div className="bg-white dark:bg-slate-900 rounded-2xl border border-gray-100 dark:border-slate-800 p-5">
       <h3 className="text-[15px] font-semibold text-gray-900 dark:text-gray-100 mb-4">거래 내역</h3>
       <table className="w-full">
@@ -66,7 +78,7 @@ export default function TradeHistory({ tickerCode, orders }: Props) {
                     </span>
                     {order.cancelable && (
                       <button
-                        onClick={() => cancelOrder(order.orderId)}
+                        onClick={() => setConfirmOrderId(order.orderId)}
                         disabled={isPending}
                         className="text-[12px] text-gray-400 dark:text-slate-500 hover:text-red-500 border border-gray-200 dark:border-slate-700 rounded px-1.5 py-0.5 transition-colors disabled:opacity-50"
                       >
@@ -81,5 +93,27 @@ export default function TradeHistory({ tickerCode, orders }: Props) {
         </tbody>
       </table>
     </div>
+
+    {confirmOrderId !== null && (
+      <div className="fixed inset-0 z-[999] flex items-center justify-center bg-black/40" onClick={() => setConfirmOrderId(null)}>
+        <div className="bg-white dark:bg-slate-900 rounded-2xl w-90 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-slate-800">
+            <p className="text-[15px] font-bold text-gray-900 dark:text-gray-100">주문 취소</p>
+            <button onClick={() => setConfirmOrderId(null)} className="text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors">
+              <X size={18} />
+            </button>
+          </div>
+          <div className="px-6 py-6">
+            <p className="text-[14px] text-gray-700 dark:text-gray-300 font-medium mb-1">주문을 취소하시겠어요?</p>
+            <p className="text-[13px] text-gray-400 dark:text-slate-500">취소된 주문은 되돌릴 수 없어요.</p>
+          </div>
+          <div className="flex gap-2 px-6 pb-6">
+            <Button variant="invalid" className="flex-1 py-2.5" onClick={() => setConfirmOrderId(null)}>닫기</Button>
+            <Button variant="primary" className="flex-1 py-2.5" onClick={handleCancelConfirm} disabled={isPending}>주문 취소</Button>
+          </div>
+        </div>
+      </div>
+    )}
+    </>
   );
 }

--- a/src/pages/mentee/MyMenteePage.tsx
+++ b/src/pages/mentee/MyMenteePage.tsx
@@ -180,9 +180,21 @@ function MenteeListItem({
   selected: boolean;
   onClick: () => void;
 }) {
-  const { data: profile } = useUserProfileQuery(userId);
+  const { data: profile, isLoading: profileLoading } = useUserProfileQuery(userId);
   const { data: summary } = useAccountSummaryByUserQuery(userId);
   const isPositive = (summary?.totalReturnRate ?? 0) >= 0;
+
+  if (profileLoading) {
+    return (
+      <div className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl animate-pulse">
+        <div className="w-9 h-9 rounded-full bg-gray-200 dark:bg-slate-700 shrink-0" />
+        <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+          <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded-full w-16" />
+          <div className="h-2.5 bg-gray-200 dark:bg-slate-700 rounded-full w-12" />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <button
@@ -193,7 +205,7 @@ function MenteeListItem({
     >
       <Avatar name={profile?.nickname ?? ""} src={profile?.imageUrl || undefined} size={36} />
       <div className="flex-1 min-w-0">
-        <p className="text-[13px] font-semibold text-gray-900 dark:text-gray-100 truncate">{profile?.nickname ?? "..."}</p>
+        <p className="text-[13px] font-semibold text-gray-900 dark:text-gray-100 truncate">{profile?.nickname}</p>
         <p className={`text-[12px] font-semibold ${isPositive ? "text-red-500" : "text-blue-500"}`}>
           {isPositive ? "+" : ""}{(summary?.totalReturnRate ?? 0).toFixed(2)}%
         </p>

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -16,7 +16,8 @@ const USERS_TOUR: TourStep[] = [
     placement: "left",
   },
 ];
-import { Search, Medal, UserPlus, GraduationCap, Crown, Users } from "lucide-react";
+import { useState } from "react";
+import { Search, Medal, UserPlus, GraduationCap, Crown, Users, X } from "lucide-react";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import Avatar from "@/components/ui/Avatar";
 import Button from "@/components/ui/Button";
@@ -141,10 +142,10 @@ function MentoringButton({
   if (user.mentoringStatus === "ACCEPTED") {
     return (
       <button
-        disabled
-        className="w-full py-1.5 rounded-[10px] text-[12px] text-white bg-orange-400 cursor-default"
+        onClick={() => onCancel(user)}
+        className="w-full py-1.5 rounded-[10px] text-[12px] text-white bg-orange-400 hover:bg-orange-500 transition-colors"
       >
-        멘토
+        멘토취소
       </button>
     );
   }
@@ -308,6 +309,8 @@ export default function UserListPage() {
   const setSortBy = (v: SortBy) =>
     setSearchParams((p) => { v === "returnRate" ? p.delete("sort") : p.set("sort", v); return p; }, { replace: true });
 
+  const [cancelTargetUser, setCancelTargetUser] = useState<UserItem | null>(null);
+
   const { data, isLoading } = useUserListQuery();
   const { toggleFollow, setMentoringStatus } = useUserListCacheUpdate();
   const queryClient = useQueryClient();
@@ -359,6 +362,13 @@ export default function UserListPage() {
   }
 
   async function handleMentoringCancel(user: UserItem) {
+    setCancelTargetUser(user);
+  }
+
+  async function confirmMentoringCancel() {
+    if (!cancelTargetUser) return;
+    const user = cancelTargetUser;
+    setCancelTargetUser(null);
     setMentoringStatus(user.userId, "NONE", false);
     try {
       await cancelMentoring(user.userId);
@@ -386,6 +396,28 @@ export default function UserListPage() {
 
   return (
     <div className="flex flex-col h-screen p-6 gap-4 overflow-hidden bg-gray-50 dark:bg-slate-950">
+      {cancelTargetUser && (
+        <div className="fixed inset-0 z-[999] flex items-center justify-center bg-black/40" onClick={() => setCancelTargetUser(null)}>
+          <div className="bg-white dark:bg-slate-900 rounded-2xl w-[360px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-slate-800">
+              <p className="text-[15px] font-bold text-gray-900 dark:text-gray-100">멘토 취소</p>
+              <button onClick={() => setCancelTargetUser(null)} className="text-gray-400 hover:text-gray-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors">
+                <X size={18} />
+              </button>
+            </div>
+            <div className="px-6 py-6">
+              <p className="text-[14px] text-gray-700 dark:text-gray-300 font-medium mb-1">
+                <span className="font-bold text-[#0046FF]">{cancelTargetUser.nickname}</span> 멘토를 취소하시겠어요?
+              </p>
+              <p className="text-[13px] text-gray-400 dark:text-slate-500">멘토 취소 후에도 다시 신청할 수 있어요.</p>
+            </div>
+            <div className="flex gap-2 px-6 pb-6">
+              <Button variant="invalid" className="flex-1 py-2.5" onClick={() => setCancelTargetUser(null)}>닫기</Button>
+              <Button variant="danger" className="flex-1 py-2.5" onClick={confirmMentoringCancel}>멘토 취소</Button>
+            </div>
+          </div>
+        </div>
+      )}
       {/* 헤더 */}
       <div className="flex items-center gap-2">
    

--- a/src/pages/users/UserProfilePage.tsx
+++ b/src/pages/users/UserProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Loader2, ChevronLeft } from "lucide-react";
+import { Loader2, ChevronLeft, X } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import UnderlineTabBar from "@/components/ui/UnderlineTabBar";
 import TradeDiaryTab from "@/components/profile/TradeDiaryTab";
@@ -17,7 +17,8 @@ import {
   useMyMentorQuery,
 } from "@/api/mentorApi";
 import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
-import { followUser, unfollowUser } from "@/api/userListApi";
+import { followUser, unfollowUser, requestMentoring, cancelMentoring } from "@/api/userListApi";
+import Button from "@/components/ui/Button";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -37,6 +38,7 @@ export default function UserProfilePage() {
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<TabId>("diary");
   const [followModal, setFollowModal] = useState<"followers" | "following" | null>("following");
+  const [showCancelModal, setShowCancelModal] = useState(false);
 
   const id = Number(userId);
   const { data: profile, isLoading } = useUserProfileQuery(id);
@@ -61,6 +63,8 @@ export default function UserProfilePage() {
 
   const isMentor = myMentor?.hasMentor && myMentor.userId === id;
   const isMentee = myMentees?.mentees.some((m) => m.userId === id);
+  const hasAcceptedMentor = myMentor?.hasMentor ?? false;
+  const mentoringStatus = (profile?.mentoringStatus ?? "NONE") as "NONE" | "PENDING" | "ACCEPTED";
 
   const handleFollow = async () => {
     if (!profile) return;
@@ -75,6 +79,27 @@ export default function UserProfilePage() {
       queryClient.invalidateQueries({ queryKey: ["follows", id, "followers"] });
       queryClient.invalidateQueries({ queryKey: ["follows", "following"] });
     } catch (e) {
+      // 실패 시 무시
+    }
+  };
+
+  const handleMentoringRequest = async () => {
+    try {
+      await requestMentoring(id);
+      queryClient.invalidateQueries({ queryKey: ["users", id] });
+      queryClient.invalidateQueries({ queryKey: ["mentor"] });
+    } catch {
+      // 실패 시 무시
+    }
+  };
+
+  const handleMentoringCancel = async () => {
+    try {
+      await cancelMentoring(id);
+      queryClient.invalidateQueries({ queryKey: ["users", id] });
+      queryClient.invalidateQueries({ queryKey: ["mentor"] });
+      setShowCancelModal(false);
+    } catch {
       // 실패 시 무시
     }
   };
@@ -103,6 +128,28 @@ export default function UserProfilePage() {
 
   return (
     <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50 dark:bg-slate-950">
+      {showCancelModal && (
+        <div className="fixed inset-0 z-[999] flex items-center justify-center bg-black/40" onClick={() => setShowCancelModal(false)}>
+          <div className="bg-white dark:bg-slate-900 rounded-2xl w-[360px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-slate-800">
+              <p className="text-[15px] font-bold text-gray-900 dark:text-gray-100">멘토 취소</p>
+              <button onClick={() => setShowCancelModal(false)} className="text-gray-400 hover:text-gray-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors">
+                <X size={18} />
+              </button>
+            </div>
+            <div className="px-6 py-6">
+              <p className="text-[14px] text-gray-700 dark:text-gray-300 font-medium mb-1">
+                <span className="font-bold text-[#0046FF]">{profile.nickname}</span> 멘토를 취소하시겠어요?
+              </p>
+              <p className="text-[13px] text-gray-400 dark:text-slate-500">멘토 취소 후에도 다시 신청할 수 있어요.</p>
+            </div>
+            <div className="flex gap-2 px-6 pb-6">
+              <Button variant="invalid" className="flex-1 py-2.5" onClick={() => setShowCancelModal(false)}>닫기</Button>
+              <Button variant="danger" className="flex-1 py-2.5" onClick={handleMentoringCancel}>멘토 취소</Button>
+            </div>
+          </div>
+        </div>
+      )}
       {/* 헤더 */}
       <div className="flex items-center gap-3 shrink-0">
         <button onClick={() => navigate(-1)} className="text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors">
@@ -127,6 +174,10 @@ export default function UserProfilePage() {
             onFollowersClick={() => setFollowModal("followers")}
             onFollowingClick={() => setFollowModal("following")}
             badge={isMentor ? "멘토" : isMentee ? "멘티" : undefined}
+            mentoringStatus={profile.me ? undefined : mentoringStatus}
+            hasAcceptedMentor={hasAcceptedMentor}
+            onMentoringRequest={handleMentoringRequest}
+            onMentoringCancel={() => setShowCancelModal(true)}
           />
           {followModal && (
             <FollowList type={followModal} userId={id} />


### PR DESCRIPTION
## #️⃣  관련 이슈
  - closed #131                                                                                                   
                  
  ## 💡 작업 배경                                                                                               
  주문 취소, 멘토 취소 시 확인 없이 바로 실행되어 사용자가 실수할 수 있는 문제와
  멘티 목록 새로고침 시 이미지/닉네임이 깜빡이는 UX 문제 개선                                                   
                                                                                                                
  ## 🧩 작업 내용                                                                                               
  - 주문 내역 취소 버튼 클릭 시 확인 모달 추가                                                                  
  - 유저 목록 멘토 버튼 클릭 시 취소 확인 모달 추가                                                             
  - 유저 프로필 페이지에 멘토신청 / 신청완료 / 멘토취소 버튼 추가                                               
  - 멘티 목록 아이템 로딩 중 스켈레톤 추가 (이미지·닉네임 깜빡임 제거)                                          
  - 팔로잉 버튼 스타일 outline(테두리+텍스트)으로 통일                                                          
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
                                                                                                                
  ## 📝 기타 