### PR TITLE
[Feat] 지정가 주문 시 호가 단위 자동 보정 기능 추가

### DIFF
--- a/src/components/stocks/TradeOrderModal.tsx
+++ b/src/components/stocks/TradeOrderModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { X, AlertCircle, Wallet, Tag, Hash, PenLine } from "lucide-react";
+import { adjustToTickSize, getTickSize } from "@/lib/tickSize";
 import Button from "@/components/ui/Button";
 import SpotlightTour from "@/components/onboarding/SpotlightTour";
 import type { TourStep } from "@/components/onboarding/SpotlightTour";
@@ -111,6 +112,7 @@ export default function TradeOrderModal({
   const [limitPrice, setLimitPrice] = useState(
     initialPrice ? String(initialPrice) : "",
   );
+  const [limitPriceAdjusted, setLimitPriceAdjusted] = useState(false);
   const [quantity, setQuantity] = useState("");
   const [diary, setDiary] = useState("");
 
@@ -208,12 +210,33 @@ export default function TradeOrderModal({
                 {currentPrice.toLocaleString()}
               </div>
             ) : (
-              <input
-                type="number"
-                value={limitPrice}
-                onChange={(e) => setLimitPrice(e.target.value)}
-                className="w-full px-4 py-2.5 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-[13px] text-gray-900 dark:text-gray-100 outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all tabular-nums"
-              />
+              <>
+                <input
+                  type="number"
+                  value={limitPrice}
+                  onChange={(e) => {
+                    setLimitPrice(e.target.value);
+                    setLimitPriceAdjusted(false);
+                  }}
+                  onBlur={() => {
+                    const raw = Number(limitPrice);
+                    if (!raw) return;
+                    const adjusted = adjustToTickSize(raw);
+                    if (adjusted !== raw) {
+                      setLimitPrice(String(adjusted));
+                      setLimitPriceAdjusted(true);
+                    } else {
+                      setLimitPriceAdjusted(false);
+                    }
+                  }}
+                  className="w-full px-4 py-2.5 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-[13px] text-gray-900 dark:text-gray-100 outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all tabular-nums"
+                />
+                {limitPriceAdjusted && (
+                  <p className="text-[11px] text-blue-500 mt-1 ml-1">
+                    호가 단위({getTickSize(Number(limitPrice)).toLocaleString()}원)에 맞게 자동 보정됐어요.
+                  </p>
+                )}
+              </>
             )}
           </div>
           <div data-tour="trade-order-quantity">

--- a/src/lib/tickSize.ts
+++ b/src/lib/tickSize.ts
@@ -1,0 +1,23 @@
+/**
+ * 한국 주식 호가 단위 기준 (KRX)
+ * 입력된 가격을 호가 단위에 맞게 내림 보정합니다.
+ */
+export function adjustToTickSize(price: number): number {
+  if (price < 2000) return Math.floor(price / 1) * 1;
+  if (price < 5000) return Math.floor(price / 5) * 5;
+  if (price < 10000) return Math.floor(price / 10) * 10;
+  if (price < 50000) return Math.floor(price / 50) * 50;
+  if (price < 100000) return Math.floor(price / 100) * 100;
+  if (price < 500000) return Math.floor(price / 500) * 500;
+  return Math.floor(price / 1000) * 1000;
+}
+
+export function getTickSize(price: number): number {
+  if (price < 2000) return 1;
+  if (price < 5000) return 5;
+  if (price < 10000) return 10;
+  if (price < 50000) return 50;
+  if (price < 100000) return 100;
+  if (price < 500000) return 500;
+  return 1000;
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #142

## 💡 작업 배경
지정가 주문 시 호가 단위 자동 보정하는 기능을 추가하였다.

## 🧩 작업 내용
- src/lib/tickSize.ts 추가 — KRX 호가 단위 기준 유틸 함수 (adjustToTickSize, getTickSize) 
- 지정가 입력 필드에 onBlur 핸들러 추가 — 입력 완료 시 호가 단위에 맞게 자동 내림 보정
- 보정 발생 시 "호가 단위(N원)에 맞게 자동 보정됐어요." 안내 문구 표시

  ┌──────────────────────────┬───────────┐
  │        가격 범위         │ 호가 단위 │
  ├──────────────────────────┼───────────┤
  │ 2,000원 미만             │ 1원       │
  ├──────────────────────────┼───────────┤
  │ 2,000 ~ 5,000원 미만     │ 5원       │
  ├──────────────────────────┼───────────┤
  │ 5,000 ~ 10,000원 미만    │ 10원      │
  ├──────────────────────────┼───────────┤
  │ 10,000 ~ 50,000원 미만   │ 50원      │
  ├──────────────────────────┼───────────┤
  │ 50,000 ~ 100,000원 미만  │ 100원     │
  ├──────────────────────────┼───────────┤
  │ 100,000 ~ 500,000원 미만 │ 500원     │
  ├──────────────────────────┼───────────┤
  │ 500,000원 이상           │ 1,000원   │
  └──────────────────────────┴───────────┘

## 📸 스크린샷(선택)
<img width="557" height="891" alt="image" src="https://github.com/user-attachments/assets/92f794a5-df8d-494a-b2c1-f5fe893864cd" />
