### PR TITLE
[Style] 알림 메시지 주요 키워드 볼드 처리

### DIFF
--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Bell, Users, Zap, CheckCircle, XCircle } from "lucide-react";
 import type { NotificationItem } from "@/api/notificationApi";
 
@@ -68,6 +69,25 @@ function getIconConfig(type: NotificationItem["notificationType"]): IconConfig {
   }
 }
 
+function formatNotificationContent(content: string): React.ReactNode {
+  const parts = content.split(/(\[[^\]]+\]|[^\s]+님|[^\s]+을\(를\))/g);
+  return parts.map((part, i) => {
+    if (/^\[[^\]]+\]$/.test(part)) {
+      const inner = part.slice(1, -1);
+      return <React.Fragment key={i}>[<strong>{inner}</strong>]</React.Fragment>;
+    }
+    if (/^[^\s]+님$/.test(part)) {
+      const name = part.slice(0, -1);
+      return <React.Fragment key={i}><strong>{name}</strong>님</React.Fragment>;
+    }
+    if (/^[^\s]+을\(를\)$/.test(part)) {
+      const word = part.slice(0, -4);
+      return <React.Fragment key={i}><strong>{word}</strong>을(를)</React.Fragment>;
+    }
+    return part;
+  });
+}
+
 export default function NotificationCard({ item, onRead, onAccept, onReject }: Props) {
   const { bg, icon, badgeText, badgeClass } = getIconConfig(item.notificationType);
   const isUnread = !item.isRead;
@@ -110,7 +130,7 @@ export default function NotificationCard({ item, onRead, onAccept, onReject }: P
 
           {/* 메시지 */}
           <p className={`text-[14px] font-medium mt-1.5 ${isUnread ? "text-gray-800 dark:text-gray-200" : "text-gray-500 dark:text-slate-400"}`}>
-            {item.content}
+            {formatNotificationContent(item.content)}
           </p>
 
           {/* 멘토 신청 액션 버튼 */}


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #148

## 💡 작업 배경
알림 메시지에서 가독성 좋게 볼드 처리를 하였다.

## 🧩 작업 내용
  - 알림 메시지(content)에서 주요 키워드를 볼드체로 강조하는 formatNotificationContent 함수 추가 
  - [종목명] → 대괄호 안 종목명 볼드 처리 (주문 체결 알림)
  - XXX님 → 이름 볼드 처리 (멘토 신청/수락/거절, 팔로우 알림)
  - XXX을(를) → 앞 단어 볼드 처리

## 📸 스크린샷(선택)
<img width="972" height="673" alt="image" src="https://github.com/user-attachments/assets/70022898-fdf3-4c71-9012-356cd55f1bdf" />
