### PR TITLE
[Feat] 멘토 신청 취소 구현

### DIFF
--- a/src/api/notificationApi.ts
+++ b/src/api/notificationApi.ts
@@ -24,6 +24,7 @@ export type NotificationItem = {
   isRead: boolean;
   actUrl: string;
   createdAt: string;
+  eventType?: "CREATE" | "DELETE";
 };
 
 export type NotificationCountResponse = {
@@ -96,6 +97,14 @@ export function useNotificationSubscription(userId: number | undefined) {
 
     const unsub = stompSubscribe(`/topic/notifications/${userId}`, (message) => {
       const item: NotificationItem = JSON.parse(message.body);
+
+      if (item.eventType === "DELETE") {
+        queryClient.setQueryData<NotificationItem[]>(
+          notificationQueryKeys.list,
+          (prev) => prev ? prev.filter((n) => n.notificationId !== item.notificationId) : prev,
+        );
+        return;
+      }
 
       queryClient.setQueryData<NotificationItem[]>(
         notificationQueryKeys.list,

--- a/src/api/userListApi.ts
+++ b/src/api/userListApi.ts
@@ -51,6 +51,10 @@ export async function cancelMentoring(mentorUserId: number): Promise<void> {
   await fetchClient.delete(`/api/mentor-requests/${mentorUserId}`);
 }
 
+export async function cancelPendingMentoring(mentorUserId: number): Promise<void> {
+  await fetchClient.delete(`/api/mentor-requests/${mentorUserId}/pending`);
+}
+
 // ─── Cache Updater ────────────────────────────────────────────────────────────
 
 export function useUserListCacheUpdate() {

--- a/src/components/profile/ProfileCard.tsx
+++ b/src/components/profile/ProfileCard.tsx
@@ -28,6 +28,7 @@ type Props = {
   hasAcceptedMentor?: boolean;
   onMentoringRequest?: () => void;
   onMentoringCancel?: () => void;
+  onPendingCancelRequest?: () => void;
 };
 
 function fmtAmount(n: number) {
@@ -57,6 +58,7 @@ export default function ProfileCard({
   hasAcceptedMentor,
   onMentoringRequest,
   onMentoringCancel,
+  onPendingCancelRequest,
 }: Props) {
   const isPositive = totalReturnRate >= 0;
 
@@ -182,8 +184,8 @@ export default function ProfileCard({
             )}
             {mentoringStatus === "PENDING" && (
               <button
-                disabled
-                className="w-full py-1.5 rounded-[10px] border border-orange-400 text-orange-400 bg-white dark:bg-slate-900 opacity-60 cursor-default"
+                onClick={onPendingCancelRequest}
+                className="w-full py-1.5 rounded-[10px] border border-orange-400 text-orange-400 bg-white dark:bg-slate-900 hover:bg-orange-50 dark:hover:bg-orange-950/20 transition-colors"
               >
                 신청완료
               </button>

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -40,6 +40,7 @@ import {
   unfollowUser,
   requestMentoring,
   cancelMentoring,
+  cancelPendingMentoring,
 } from "@/api/userListApi";
 import type { UserItem } from "@/api/userListApi";
 import {
@@ -114,11 +115,13 @@ function MentoringButton({
   hasAcceptedMentor,
   onRequest,
   onCancel,
+  onPendingCancel,
 }: {
   user: UserItem;
   hasAcceptedMentor: boolean;
   onRequest: (user: UserItem) => void;
   onCancel: (user: UserItem) => void;
+  onPendingCancel: (user: UserItem) => void;
 }) {
   if (user.me) return null;
 
@@ -138,8 +141,8 @@ function MentoringButton({
   if (user.mentoringStatus === "PENDING") {
     return (
       <button
-        disabled
-        className="w-full py-1.5 rounded-[10px] text-[12px] border border-orange-400 text-orange-400 bg-white cursor-default opacity-60"
+        onClick={() => onPendingCancel(user)}
+        className="w-full py-1.5 rounded-[10px] text-[12px] border border-orange-400 text-orange-400 bg-white hover:bg-orange-50 transition-colors"
       >
         신청완료
       </button>
@@ -214,6 +217,7 @@ function UserRow({
   onFollowToggle,
   onMentoringRequest,
   onMentoringCancel,
+  onPendingCancel,
   isFirstNonMe,
 }: {
   user: UserItem;
@@ -224,6 +228,7 @@ function UserRow({
   onFollowToggle: (user: UserItem) => void;
   onMentoringRequest: (user: UserItem) => void;
   onMentoringCancel: (user: UserItem) => void;
+  onPendingCancel: (user: UserItem) => void;
   isFirstNonMe?: boolean;
 }) {
   const navigate = useNavigate();
@@ -295,6 +300,7 @@ function UserRow({
           hasAcceptedMentor={hasAcceptedMentor}
           onRequest={onMentoringRequest}
           onCancel={onMentoringCancel}
+          onPendingCancel={onPendingCancel}
         />
       </td>
     </tr>
@@ -326,9 +332,8 @@ export default function UserListPage() {
       { replace: true },
     );
 
-  const [cancelTargetUser, setCancelTargetUser] = useState<UserItem | null>(
-    null,
-  );
+  const [cancelTargetUser, setCancelTargetUser] = useState<UserItem | null>(null);
+  const [pendingCancelTargetUser, setPendingCancelTargetUser] = useState<UserItem | null>(null);
 
   const { data, isLoading } = useUserListQuery();
   const { toggleFollow, setMentoringStatus } = useUserListCacheUpdate();
@@ -403,6 +408,22 @@ export default function UserListPage() {
     }
   }
 
+  async function handlePendingMentoringCancel(user: UserItem) {
+    setPendingCancelTargetUser(user);
+  }
+
+  async function confirmPendingCancel() {
+    if (!pendingCancelTargetUser) return;
+    const user = pendingCancelTargetUser;
+    setPendingCancelTargetUser(null);
+    setMentoringStatus(user.userId, "NONE", hasAcceptedMentor);
+    try {
+      await cancelPendingMentoring(user.userId);
+    } catch {
+      setMentoringStatus(user.userId, "PENDING", hasAcceptedMentor);
+    }
+  }
+
   const filtered = allUsers
     .filter((u) => tab === "전체" || u.following || u.me)
     .filter((u) => !search || u.nickname.includes(search));
@@ -474,6 +495,56 @@ export default function UserListPage() {
                 onClick={confirmMentoringCancel}
               >
                 멘토 취소
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+      {pendingCancelTargetUser && (
+        <div
+          className="fixed inset-0 z-[999] flex items-center justify-center bg-black/40"
+          onClick={() => setPendingCancelTargetUser(null)}
+        >
+          <div
+            className="bg-white dark:bg-slate-900 rounded-2xl w-[360px] shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-slate-800">
+              <p className="text-[15px] font-bold text-gray-900 dark:text-gray-100">
+                신청 취소
+              </p>
+              <button
+                onClick={() => setPendingCancelTargetUser(null)}
+                className="text-gray-400 hover:text-gray-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors"
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <div className="px-6 py-6">
+              <p className="text-[14px] text-gray-700 dark:text-gray-300 font-medium mb-1">
+                <span className="font-bold text-[#0046FF]">
+                  {pendingCancelTargetUser.nickname}
+                </span>{" "}
+                멘토 신청을 취소하시겠어요?
+              </p>
+              <p className="text-[13px] text-gray-400 dark:text-slate-500">
+                취소 후에도 다시 신청할 수 있어요.
+              </p>
+            </div>
+            <div className="flex gap-2 px-6 pb-6">
+              <Button
+                variant="invalid"
+                className="flex-1 py-2.5"
+                onClick={() => setPendingCancelTargetUser(null)}
+              >
+                닫기
+              </Button>
+              <Button
+                variant="danger"
+                className="flex-1 py-2.5"
+                onClick={confirmPendingCancel}
+              >
+                신청 취소
               </Button>
             </div>
           </div>
@@ -619,6 +690,7 @@ export default function UserListPage() {
                           onFollowToggle={handleFollowToggle}
                           onMentoringRequest={handleMentoringRequest}
                           onMentoringCancel={handleMentoringCancel}
+                          onPendingCancel={handlePendingMentoringCancel}
                           isFirstNonMe={i === firstNonMeIdx}
                         />
                       );

--- a/src/pages/users/UserProfilePage.tsx
+++ b/src/pages/users/UserProfilePage.tsx
@@ -17,7 +17,7 @@ import {
   useMyMentorQuery,
 } from "@/api/mentorApi";
 import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
-import { followUser, unfollowUser, requestMentoring, cancelMentoring } from "@/api/userListApi";
+import { followUser, unfollowUser, requestMentoring, cancelMentoring, cancelPendingMentoring } from "@/api/userListApi";
 import Button from "@/components/ui/Button";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -39,6 +39,7 @@ export default function UserProfilePage() {
   const [activeTab, setActiveTab] = useState<TabId>("portfolio");
   const [followModal, setFollowModal] = useState<"followers" | "following" | null>("following");
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [showPendingCancelModal, setShowPendingCancelModal] = useState(false);
 
   const id = Number(userId);
   const { data: profile, isLoading } = useUserProfileQuery(id);
@@ -104,6 +105,17 @@ export default function UserProfilePage() {
     }
   };
 
+  const handlePendingMentoringCancel = async () => {
+    try {
+      await cancelPendingMentoring(id);
+      queryClient.invalidateQueries({ queryKey: ["users", id] });
+      queryClient.invalidateQueries({ queryKey: ["mentor"] });
+      setShowPendingCancelModal(false);
+    } catch {
+      // 실패 시 무시
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-full min-h-screen">
@@ -128,6 +140,28 @@ export default function UserProfilePage() {
 
   return (
     <div className="flex flex-col h-screen p-6 gap-5 overflow-hidden bg-gray-50 dark:bg-slate-950">
+      {showPendingCancelModal && (
+        <div className="fixed inset-0 z-[999] flex items-center justify-center bg-black/40" onClick={() => setShowPendingCancelModal(false)}>
+          <div className="bg-white dark:bg-slate-900 rounded-2xl w-[360px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-slate-800">
+              <p className="text-[15px] font-bold text-gray-900 dark:text-gray-100">신청 취소</p>
+              <button onClick={() => setShowPendingCancelModal(false)} className="text-gray-400 hover:text-gray-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors">
+                <X size={18} />
+              </button>
+            </div>
+            <div className="px-6 py-6">
+              <p className="text-[14px] text-gray-700 dark:text-gray-300 font-medium mb-1">
+                <span className="font-bold text-[#0046FF]">{profile?.nickname}</span> 멘토 신청을 취소하시겠어요?
+              </p>
+              <p className="text-[13px] text-gray-400 dark:text-slate-500">취소 후에도 다시 신청할 수 있어요.</p>
+            </div>
+            <div className="flex gap-2 px-6 pb-6">
+              <Button variant="invalid" className="flex-1 py-2.5" onClick={() => setShowPendingCancelModal(false)}>닫기</Button>
+              <Button variant="danger" className="flex-1 py-2.5" onClick={handlePendingMentoringCancel}>신청 취소</Button>
+            </div>
+          </div>
+        </div>
+      )}
       {showCancelModal && (
         <div className="fixed inset-0 z-[999] flex items-center justify-center bg-black/40" onClick={() => setShowCancelModal(false)}>
           <div className="bg-white dark:bg-slate-900 rounded-2xl w-[360px] shadow-2xl" onClick={(e) => e.stopPropagation()}>
@@ -178,6 +212,7 @@ export default function UserProfilePage() {
             hasAcceptedMentor={hasAcceptedMentor}
             onMentoringRequest={handleMentoringRequest}
             onMentoringCancel={() => setShowCancelModal(true)}
+            onPendingCancelRequest={() => setShowPendingCancelModal(true)}
           />
           {followModal && (
             <FollowList type={followModal} userId={id} />


### PR DESCRIPTION
## #️⃣  관련 이슈                       
  - closed #154 
                                                                                                                
  ## 💡 작업 배경                                                                                               
  멘토 신청 후 취소가 불가능한 문제가 있었습니다.                                                               
  PENDING 상태의 버튼이 비활성화되어 있어 신청 취소를 할 수 없었고,                                             
  WebSocket 알림도 취소 이벤트를 처리하지 못하는 상태였습니다.                                                  
                                                                                                                
  ## 🧩 작업 내용                                                                                               
  - 유저 목록 및 유저 프로필에서 `신청완료` 버튼 클릭 시 멘토 신청 취소 가능하도록 변경                         
    - 기존: `신청완료` 버튼 disabled 처리                                                                       
    - 변경: 버튼 클릭 → 확인 모달 → `DELETE /api/mentor-requests/{mentorUserId}/pending` 호출 → 상태 `PENDING → 
  NONE` 으로 업데이트                                                                                           
  - `NotificationItem` 타입에 `eventType` 필드 추가 (`"CREATE" | "DELETE"`)                                     
  - WebSocket 수신 시 `eventType: "DELETE"` 분기 처리 추가                                                      
    - `notificationId` 기준으로 알림 목록에서 해당 항목 실시간 제거                                             
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
                                                                                                                
  ## 📝 기타