### PR TITLE
[Feat] 매수/매도 주문 오류 피드백 개선

### DIFF
--- a/src/components/stocks/TradeOrderModal.tsx
+++ b/src/components/stocks/TradeOrderModal.tsx
@@ -114,6 +114,7 @@ export default function TradeOrderModal({
   const [limitPriceAdjusted, setLimitPriceAdjusted] = useState(false);
   const [quantity, setQuantity] = useState("");
   const [diary, setDiary] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   const execPrice =
     orderType === "MARKET" ? currentPrice : Number(limitPrice) || 0;
@@ -124,6 +125,19 @@ export default function TradeOrderModal({
     qty > 0 &&
     diary.trim().length > 0 &&
     (orderType === "MARKET" || execPrice > 0);
+
+  const handleSubmit = () => {
+    if (isBuy && totalAmount > cash) {
+      setValidationError("잔액이 부족합니다. 주문 금액을 확인해 주세요.");
+      return;
+    }
+    if (!isBuy && qty > holdingQuantity) {
+      setValidationError("보유 수량이 부족합니다. 주문 수량을 확인해 주세요.");
+      return;
+    }
+    setValidationError(null);
+    onConfirm({ orderType, price: execPrice, quantity: qty, diary });
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
@@ -305,6 +319,14 @@ export default function TradeOrderModal({
 
         <SpotlightTour tourKey="trade-order" steps={TRADE_ORDER_TOUR} />
 
+        {/* 유효성 에러 메시지 */}
+        {validationError && (
+          <p className="flex items-center gap-1.5 text-[12px] font-semibold text-red-500 bg-red-50 dark:bg-red-500/10 rounded-xl px-4 py-2.5 mb-3">
+            <AlertCircle size={14} />
+            {validationError}
+          </p>
+        )}
+
         {/* 하단 버튼 */}
         <div className="flex gap-3">
           <button
@@ -315,9 +337,7 @@ export default function TradeOrderModal({
           </button>
           <button
             disabled={!canSubmit}
-            onClick={() =>
-              onConfirm({ orderType, price: execPrice, quantity: qty, diary })
-            }
+            onClick={handleSubmit}
             className={`flex-[1.5] py-3.5 rounded-xl text-[14px] font-bold text-white transition-all disabled:opacity-30 disabled:grayscale ${accent.bg}`}
           >
             {isBuy ? "매수하기" : "매도하기"}

--- a/src/index.css
+++ b/src/index.css
@@ -53,3 +53,12 @@
 .animate-float {
   animation: float 2.4s ease-in-out infinite;
 }
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+
+.animate-fade-in {
+  animation: fade-in-up 0.2s ease-out forwards;
+}

--- a/src/pages/stocks/[stockId]/StockDetailPage.tsx
+++ b/src/pages/stocks/[stockId]/StockDetailPage.tsx
@@ -128,6 +128,12 @@ export default function StockDetailPage() {
   const [orderSide, setOrderSide] = useState<OrderSide | null>(null);
   const [selectedPrice, setSelectedPrice] = useState<number | null>(null);
   const [pendingOrder, setPendingOrder] = useState<PendingOrder | null>(null);
+  const [errorToast, setErrorToast] = useState<string | null>(null);
+
+  const showErrorToast = (msg: string) => {
+    setErrorToast(msg);
+    setTimeout(() => setErrorToast(null), 3500);
+  };
 
   const buyMutation = useBuyOrderMutation();
   const sellMutation = useSellOrderMutation();
@@ -359,11 +365,29 @@ export default function StockDetailPage() {
                 });
                 setPendingOrder(null);
               },
+              onError: (err: unknown) => {
+                setPendingOrder(null);
+                const code = (err as { data?: { code?: string } })?.data?.code;
+                if (code === "INSUFFICIENT_CASH") {
+                  showErrorToast("잔액이 부족합니다. 주문 금액을 확인해 주세요.");
+                } else if (code === "INSUFFICIENT_HOLDINGS") {
+                  showErrorToast("보유 수량이 부족합니다. 주문 수량을 확인해 주세요.");
+                } else {
+                  showErrorToast("주문에 실패했습니다. 다시 시도해 주세요.");
+                }
+              },
             });
           }}
         />
       )}
       <SpotlightTour tourKey="stock-detail" steps={STOCK_DETAIL_TOUR} hidden={!!orderSide || !!pendingOrder} />
+
+      {errorToast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] flex items-center gap-2 bg-red-500 text-white text-[13px] font-semibold px-5 py-3 rounded-xl shadow-lg animate-fade-in">
+          <span>⚠️</span>
+          {errorToast}
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #90

## 💡 작업 배경
- 매수/매도 주문 시 잔액·보유 수량 부족 여부를 주문 확인 모달 진입 전에 사전 검증
- - 백엔드에서 주문 거절 응답(INSUFFICIENT_CASH, INSUFFICIENT_HOLDINGS) 수신 시 에러 토스트 표시

## 🧩 작업 내용
  - TradeOrderModal — "매수하기/매도하기" 클릭 시 클라이언트 사이드 검증 추가. 잔액/수량 부족이면
   모달 내부에 인라인 에러 메시지 표시, 확인 모달로 넘어가지 않음
  - StockDetailPage — API 에러 응답 코드에 따라 하단 토스트 메시지 표시 (INSUFFICIENT_CASH /     
  INSUFFICIENT_HOLDINGS / 기타)
  - index.css — 토스트 fade-in 애니메이션 추가

## 📸 스크린샷(선택)

<img width="587" height="166" alt="image" src="https://github.com/user-attachments/assets/e77a3272-a928-45ba-b80e-4ef3f6cc3866" />
