### PR TITLE
[Fix] favicon 오류 수정

### DIFF
--- a/src/pages/stocks/[stockId]/StockDetailPage.tsx
+++ b/src/pages/stocks/[stockId]/StockDetailPage.tsx
@@ -206,7 +206,13 @@ export default function StockDetailPage() {
     if (!quote) return;
     const rate = quote.changeRate;
     document.title = `${quote.currentPrice.toLocaleString()}원 ${rate > 0 ? "+" : ""}${rate.toFixed(2)}% | ${quote.stockName}`;
+    return () => {
+      document.title = "SOLMATE";
+    };
+  }, [quote]);
 
+  useEffect(() => {
+    if (!quote?.stockLogo) return;
     const setFavicon = (href: string) => {
       const existing = document.querySelector("link[rel='icon']");
       if (existing) existing.remove();
@@ -215,14 +221,11 @@ export default function StockDetailPage() {
       link.href = href;
       document.head.appendChild(link);
     };
-
-    if (quote.stockLogo) setFavicon(quote.stockLogo);
-
+    setFavicon(quote.stockLogo);
     return () => {
-      document.title = "SOLMATE";
       setFavicon("/solmate_logo.png");
     };
-  }, [quote]);
+  }, [quote?.stockLogo]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## #️⃣  관련 이슈                           
  - closed #163 
                                                                                                                
  ## 💡 작업 배경
  StockDetailPage에서 favicon이 네트워크 탭에 반복적으로 요청되는 문제가 발생함.                                
  STOMP WebSocket으로 실시간 가격이 업데이트될 때마다 `quote`가 변경되어 favicon useEffect가 실행되었고,        
  cleanup 시 `/solmate_logo.png`로 복구 → 재실행 시 주식 로고로 변경하는 사이클이 무한 반복됨.                  
                                                                                                                
  ## 🧩 작업 내용                                                                                               
  - `StockDetailPage`의 favicon/title 업데이트 `useEffect`를 두 개로 분리                                       
    - title 업데이트: `[quote]` 의존성 유지 (실시간 가격 반영)                                                  
    - favicon 업데이트: `[quote?.stockLogo]` 의존성으로 변경 (컴포넌트 마운트 시 1회만 실행)                    
  - `stockLogo`는 STOMP 실시간 업데이트 대상이 아니므로 favicon 불필요한 재요청 제거                            
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
                                                                                                                
  ## 📝 기타