### PR TITLE
[Refactor] 캔들 차트 실시간으로 그려질 수 있도록 수정

### DIFF
--- a/src/components/stocks/StockChart.tsx
+++ b/src/components/stocks/StockChart.tsx
@@ -7,8 +7,9 @@ import {
   type UTCTimestamp,
   type IChartApi,
 } from "lightweight-charts";
-import { useCandleQuery, type PeriodType } from "@/api/stockApi";
+import { useCandleQuery, type CandleData, type PeriodType } from "@/api/stockApi";
 import { useThemeStore } from "@/store/themeStore";
+import { stompSubscribe } from "@/lib/stompClient";
 
 // --- 증권사 표준 색상 정의 ---
 const COLORS = {
@@ -112,6 +113,8 @@ export default function StockChart({ stockCode }: Props) {
   const volumeSeriesRef = useRef<any>(null);
   const loadingMoreRef = useRef(false);
   const isInitialLoadRef = useRef(true);
+  const lastRestCandleRef = useRef<CandleData | null>(null);
+  const firstDailyVolumeRef = useRef<number | null>(null);
 
   const isMinute = MINUTE_PERIODS.has(period);
   const { data: candles, isPending } = useCandleQuery(stockCode, period, limit);
@@ -336,11 +339,99 @@ export default function StockChart({ stockCode }: Props) {
       isInitialLoadRef.current = false;
     }
     loadingMoreRef.current = false;
+
+    // 주/월/년봉 STOMP 집계를 위해 마지막 REST 봉 저장
+    if (!isMinute && sorted.length > 0) {
+      lastRestCandleRef.current = sorted[sorted.length - 1];
+      firstDailyVolumeRef.current = null; // 기간 전환 또는 새 데이터 로드 시 리셋
+    }
   }, [candles, isMinute, period]);
 
   useEffect(() => {
     updateData();
   }, [updateData]);
+
+  // 분봉 실시간 구독
+  useEffect(() => {
+    if (!MINUTE_PERIODS.has(period) || !stockCode) return;
+
+    const unsub = stompSubscribe(
+      `/topic/stocks/${stockCode}/candle/${period}min`,
+      (message) => {
+        const candle: CandleData = JSON.parse(message.body);
+        const chartTime = toChartTime(candle.time, true);
+
+        candleSeriesRef.current?.update({
+          time: chartTime,
+          open: candle.open,
+          high: candle.high,
+          low: candle.low,
+          close: candle.close,
+        });
+        volumeSeriesRef.current?.update({
+          time: chartTime,
+          value: candle.volume,
+          color: candle.close >= candle.open ? UP_COLOR : DOWN_COLOR,
+        });
+      },
+    );
+
+    return unsub;
+  }, [period, stockCode]);
+
+  // 일/주/월/년봉 실시간 구독 (1day 토픽으로 통합)
+  useEffect(() => {
+    if (MINUTE_PERIODS.has(period) || !stockCode) return;
+
+    const unsub = stompSubscribe(
+      `/topic/stocks/${stockCode}/candle/1day`,
+      (message) => {
+        const daily: CandleData = JSON.parse(message.body);
+
+        if (period === "day") {
+          const chartTime = toChartTime(daily.time, false);
+          candleSeriesRef.current?.update({
+            time: chartTime,
+            open: daily.open,
+            high: daily.high,
+            low: daily.low,
+            close: daily.close,
+          });
+          volumeSeriesRef.current?.update({
+            time: chartTime,
+            value: daily.volume,
+            color: daily.close >= daily.open ? UP_COLOR : DOWN_COLOR,
+          });
+          return;
+        }
+
+        // 주/월/년봉: 마지막 REST 봉에 오늘 일봉 데이터를 합산
+        const base = lastRestCandleRef.current;
+        if (!base) return;
+
+        if (firstDailyVolumeRef.current === null) {
+          firstDailyVolumeRef.current = daily.volume;
+        }
+        const volumeDelta = daily.volume - firstDailyVolumeRef.current;
+
+        const chartTime = toChartTime(base.time, false);
+        candleSeriesRef.current?.update({
+          time: chartTime,
+          open: base.open,
+          high: Math.max(base.high, daily.high),
+          low: Math.min(base.low, daily.low),
+          close: daily.close,
+        });
+        volumeSeriesRef.current?.update({
+          time: chartTime,
+          value: base.volume + volumeDelta,
+          color: daily.close >= base.open ? UP_COLOR : DOWN_COLOR,
+        });
+      },
+    );
+
+    return unsub;
+  }, [period, stockCode]);
 
   return (
     <div className="bg-white rounded-2xl border border-gray-100 dark:bg-slate-900 dark:border-slate-900">


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #162 

## 💡 작업 배경
StockChart가 최초 REST 로드 후 차트가 멈추는 문제. 
STOMP 인프라(stompSubscribe)는 이미 있었지만 캔들 차트에 연결되지 않았음.

## 🧩 작업 내용

StockChart.tsx에 STOMP 실시간 구독 추가

  - 분봉 (1/5/30/60분): /topic/stocks/{code}/candle/{n}min 구독 → series.update()로 현재 봉 갱신 또는 새 봉 추가
  - 일봉: /topic/stocks/{code}/candle/1day 구독 → 분봉과 동일 방식
  - 주/월/년봉: 동일 1day 토픽 구독 → REST로 로드한 마지막 봉을 기준으로 close / high(max) / low(min) / volume(delta) 실시간 갱신.
    별도 백엔드 토픽 없이 프론트 집계로 처리.
  - 기간 탭 전환 시 이전 구독 자동 해제, 집계 기준값 리셋

## 📸 스크린샷(선택)


## 📝 기타

lightweight-charts의 series.update()는 time이 같으면 덮어쓰기, 새 time이면 봉 추가를 자동으로 처리하므로 분기 로직 불필요.