### PR TITLE
[Feat] 홈 인기 종목 데이터 수신 방식을 폴링에서 웹소켓 실시간 구독으로 전환

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
 import SpotlightTour from "@/components/onboarding/SpotlightTour";
 import type { TourStep } from "@/components/onboarding/SpotlightTour";
 
@@ -105,8 +106,12 @@ import {
   fetchAccountSummaryByUser,
 } from "@/api/accountSummaryApi";
 import type { AccountSummaryData } from "@/api/accountSummaryApi";
-import { useStocksQuery } from "@/api/stockApi";
-import type { StockItem } from "@/api/stockApi";
+import {
+  fetchStocks,
+  parseStockItemMessage,
+} from "@/api/stockApi";
+import type { StockItem, StockItemMessage } from "@/api/stockApi";
+import { stompSubscribe } from "@/lib/stompClient";
 
 // ─── 날짜 ─────────────────────────────────────────────────────────────────────
 
@@ -667,7 +672,42 @@ export default function HomePage() {
     useHoldingsQuery();
   const { data: userListData, isLoading: loadingUsers } =
     useUserListInfiniteQuery();
-  const { data: stocks = [], isLoading: loadingStocks } = useStocksQuery();
+  const [stocks, setStocks] = useState<StockItem[]>([]);
+  const [loadingStocks, setLoadingStocks] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const cleanupFns: Array<() => void> = [];
+
+    fetchStocks().then((initialStocks) => {
+      if (cancelled) return;
+      setStocks(initialStocks);
+      setLoadingStocks(false);
+
+      initialStocks.forEach(({ tickerCode }) => {
+        const cleanup = stompSubscribe(
+          `/topic/stocks/${tickerCode}/quote`,
+          (message) => {
+            const msg: StockItemMessage = JSON.parse(message.body);
+            const updated = parseStockItemMessage(msg);
+            setStocks((prev) =>
+              prev.map((item) =>
+                item.tickerCode === updated.tickerCode
+                  ? { ...item, ...updated }
+                  : item,
+              ),
+            );
+          },
+        );
+        cleanupFns.push(cleanup);
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      cleanupFns.forEach((fn) => fn());
+    };
+  }, []);
 
   const allUsers = userListData?.pages.flatMap((p) => p.users) ?? [];
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #165

## 💡 작업 배경
현재 홈에서 인기종목이 실시간으로 안들어왔다.

## 🧩 작업 내용
웹소켓으로 실시간 변경
- useStocksQuery() (React Query 폴링) → fetchStocks() + STOMP 웹소켓 구독으로 전환
  - 컴포넌트 마운트 시 초기 데이터 1회 HTTP 요청 후, 각 종목별 /topic/stocks/{tickerCode}/quote  
  구독
  - 웹소켓 메시지 수신 시 currentPrice, changeRate, volume 실시간 갱신
  - 언마운트 시 모든 구독 cleanup 처리
