### PR TITLE
[Refactor] 주가 차트 무한 스크롤 to 파라미터 연동 및 년봉 초기 표시 개선

### DIFF
--- a/src/api/stockApi.ts
+++ b/src/api/stockApi.ts
@@ -372,19 +372,20 @@ export async function fetchStocks(): Promise<StockItem[]> {
   return res.data.map((s) => ({ ...s, stockLogo: toLogoUrl(s.stockLogo) }));
 }
 
-export function useCandleQuery(stockCode: string, period: PeriodType, limit = 365) {
+export function useCandleQuery(stockCode: string, period: PeriodType, limit = 365, to?: number) {
   const url = (() => {
+    const toParam = to ? `&to=${to}` : "";
     if (period === "1" || period === "5" || period === "30" || period === "60") {
-      return `/api/stocks/${stockCode}/candles/minute?unit=${period}`;
+      return `/api/stocks/${stockCode}/candles/minute?unit=${period}${toParam}`;
     }
-    if (period === "day") return `/api/stocks/${stockCode}/candles/daily?days=${limit}`;
-    if (period === "week") return `/api/stocks/${stockCode}/candles/weekly?weeks=${Math.ceil(limit / 7)}`;
-    if (period === "month") return `/api/stocks/${stockCode}/candles/monthly?months=${Math.ceil(limit / 30)}`;
-    return `/api/stocks/${stockCode}/candles/yearly?years=${Math.ceil(limit / 365)}`;
+    if (period === "day") return `/api/stocks/${stockCode}/candles/daily?days=${limit}${toParam}`;
+    if (period === "week") return `/api/stocks/${stockCode}/candles/weekly?weeks=${Math.ceil(limit / 7)}${toParam}`;
+    if (period === "month") return `/api/stocks/${stockCode}/candles/monthly?months=${Math.ceil(limit / 30)}${toParam}`;
+    return `/api/stocks/${stockCode}/candles/yearly?years=${Math.ceil(limit / 365)}${toParam}`;
   })();
 
   return useQuery({
-    queryKey: [...stockQueryKeys.candles(stockCode, period), limit],
+    queryKey: [...stockQueryKeys.candles(stockCode, period), limit, to],
     queryFn: () =>
       fetchClient
         .get<ApiResponse<CandleData[]>>(url)

--- a/src/components/stocks/StockChart.tsx
+++ b/src/components/stocks/StockChart.tsx
@@ -7,7 +7,11 @@ import {
   type UTCTimestamp,
   type IChartApi,
 } from "lightweight-charts";
-import { useCandleQuery, type CandleData, type PeriodType } from "@/api/stockApi";
+import {
+  useCandleQuery,
+  type CandleData,
+  type PeriodType,
+} from "@/api/stockApi";
 import { useThemeStore } from "@/store/themeStore";
 import { stompSubscribe } from "@/lib/stompClient";
 
@@ -44,7 +48,7 @@ const INITIAL_LIMIT: Record<PeriodType, number> = {
   day: 365,
   week: 365 * 3,
   month: 365 * 5,
-  year: 365 * 10,
+  year: 365 * 50,
 };
 
 const INITIAL_VISIBLE_CANDLES: Record<PeriodType, number> = {
@@ -57,9 +61,6 @@ const INITIAL_VISIBLE_CANDLES: Record<PeriodType, number> = {
   month: 60,
   year: 10,
 };
-
-const LOAD_MORE_STEP = 365;
-const MAX_LIMIT = 365 * 20;
 
 const UP_COLOR = "#F04452";
 const DOWN_COLOR = "#3B7DEB";
@@ -101,6 +102,7 @@ interface Props {
 export default function StockChart({ stockCode }: Props) {
   const [period, setPeriod] = useState<PeriodType>("1");
   const [limit, setLimit] = useState(INITIAL_LIMIT["1"]);
+  const [toTimestamp, setToTimestamp] = useState<number | undefined>(undefined);
   const [ohlcv, setOhlcv] = useState<OhlcvInfo | null>(null);
   const isDark = useThemeStore((s) => s.theme === "dark");
 
@@ -114,14 +116,24 @@ export default function StockChart({ stockCode }: Props) {
   const isInitialLoadRef = useRef(true);
   const lastRestCandleRef = useRef<CandleData | null>(null);
   const firstDailyVolumeRef = useRef<number | null>(null);
+  const allCandlesRef = useRef<CandleData[]>([]);
+  const noMoreDataRef = useRef(false);
 
   const isMinute = MINUTE_PERIODS.has(period);
-  const { data: candles, isPending } = useCandleQuery(stockCode, period, limit);
+  const { data: candles, isPending } = useCandleQuery(
+    stockCode,
+    period,
+    limit,
+    toTimestamp,
+  );
 
   const handlePeriodChange = (p: PeriodType) => {
     isInitialLoadRef.current = true;
     setPeriod(p);
     setLimit(INITIAL_LIMIT[p]);
+    setToTimestamp(undefined);
+    allCandlesRef.current = [];
+    noMoreDataRef.current = false;
     setOhlcv(null);
   };
 
@@ -255,9 +267,12 @@ export default function StockChart({ stockCode }: Props) {
     // 왼쪽으로 스크롤 시 추가 로드
     chart.timeScale().subscribeVisibleLogicalRangeChange((range) => {
       if (!range) return;
-      if (!loadingMoreRef.current && range.from < 10) {
-        loadingMoreRef.current = true;
-        setLimit((prev) => Math.min(prev + LOAD_MORE_STEP, MAX_LIMIT));
+      if (!loadingMoreRef.current && !noMoreDataRef.current && range.from < 10) {
+        const oldest = allCandlesRef.current[0];
+        if (oldest) {
+          loadingMoreRef.current = true;
+          setToTimestamp(oldest.time);
+        }
       }
     });
 
@@ -287,7 +302,10 @@ export default function StockChart({ stockCode }: Props) {
         horzLine: { color: isDark ? "#4b5563" : "#D1D5DB" },
       },
     });
-    chartRef.current.panes()[1]?.priceScale("right").applyOptions({ textColor });
+    chartRef.current
+      .panes()[1]
+      ?.priceScale("right")
+      .applyOptions({ textColor });
   }, [isDark]);
 
   // 기간 변경 시 timeVisible 동기화
@@ -300,11 +318,19 @@ export default function StockChart({ stockCode }: Props) {
     if (!candles || !candleSeriesRef.current || !volumeSeriesRef.current)
       return;
 
-    const timeMap = new Map<string, (typeof candles)[0]>();
-    for (const c of [...candles].sort((a, b) => a.time - b.time)) {
+    const prevAllLength = allCandlesRef.current.length;
+    const merged = [...allCandlesRef.current, ...candles];
+    const timeMap = new Map<string, CandleData>();
+    for (const c of merged.sort((a, b) => a.time - b.time)) {
       timeMap.set(toChartTime(c.time, isMinute).toString(), c);
     }
     const sorted = [...timeMap.values()].sort((a, b) => a.time - b.time);
+
+    // 스크롤로 추가 요청했는데 새 데이터가 없으면 더 이상 요청 안 함
+    if (loadingMoreRef.current && sorted.length === prevAllLength) {
+      noMoreDataRef.current = true;
+    }
+    allCandlesRef.current = sorted;
 
     candleSeriesRef.current.setData(
       sorted.map((c) => ({
@@ -324,7 +350,11 @@ export default function StockChart({ stockCode }: Props) {
       })),
     );
 
-    if (!loadingMoreRef.current && isInitialLoadRef.current) {
+    if (period === "year") {
+      // 년봉은 데이터 추가될 때마다 항상 전체 fit (초기 로드 및 스크롤 추가 모두)
+      chartRef.current?.timeScale().fitContent();
+      isInitialLoadRef.current = false;
+    } else if (!loadingMoreRef.current && isInitialLoadRef.current) {
       const total = sorted.length;
       const visible = INITIAL_VISIBLE_CANDLES[period];
       if (total > visible) {
@@ -482,7 +512,9 @@ export default function StockChart({ stockCode }: Props) {
               {ohlcv.close.toLocaleString()}
             </span>
             <span className="text-gray-400 dark:text-slate-500">거래량</span>
-            <span className="text-gray-700 dark:text-gray-300">{formatVolume(ohlcv.volume)}</span>
+            <span className="text-gray-700 dark:text-gray-300">
+              {formatVolume(ohlcv.volume)}
+            </span>
           </div>
         )}
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #173 

## 💡 작업 배경

백엔드에서 모든 캔들 엔드포인트에 to 파라미터를 추가하여 특정 시점 이전 데이터를 청크 단위로 조회할 수 있게 됨. 기존 프론트의 limit 누적 방식으로는 과거 데이터 조회에 한계가 있었고, 년봉 초기 로드 시 캔들이 화면 오른쪽에 몰리는 UI 문제도 존재했음.


## 🧩 작업 내용

  - useCandleQuery에 to?: number 파라미터 추가, 모든 캔들 엔드포인트 URL에 &to= 반영
  - 무한 스크롤 방식 변경: limit 누적 → 가장 오래된 캔들의 time을 to로 전달하는 청크 페이지네이션
  - allCandlesRef로 청크 단위 데이터 누적 병합
  - noMoreDataRef로 백엔드 데이터 소진 시 재요청 방지
  - 년봉 INITIAL_LIMIT 10년 → 50년으로 확대 (전체 히스토리 초기 로드)
  - 년봉 데이터 업데이트 시 항상 fitContent() 적용하여 초기 로드 시 캔들 오른쪽 쏠림 현상 해결

## 📸 스크린샷(선택)


## 📝 기타

백엔드 to 파라미터 지원이 선행되어야 정상 동작함.