### PR TITLE
[Fix] 웹소켓 끊기지 않게 수정

### DIFF
--- a/src/lib/stompClient.ts
+++ b/src/lib/stompClient.ts
@@ -64,6 +64,12 @@ export function stompSubscribe(
   };
 }
 
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") {
+    worker.port.postMessage({ type: "PING" });
+  }
+});
+
 window.addEventListener("beforeunload", () => {
   worker.port.postMessage({ type: "DISCONNECT" });
   worker.port.close();

--- a/src/lib/stompSharedWorker.ts
+++ b/src/lib/stompSharedWorker.ts
@@ -16,18 +16,20 @@ const topicSubscriptions = new Map<
 
 let stompClient: Client | null = null;
 let wsConnectionCount = 0; // WebSocket 연결 생성 횟수
+let lastWsUrl: string | undefined;
 
 function checkConnectionRequired(wsUrl?: string) {
   const needsConnection = connectedPorts.size > 0;
+  if (wsUrl) lastWsUrl = wsUrl;
 
-  if (needsConnection && !stompClient && wsUrl) {
+  if (needsConnection && !stompClient && lastWsUrl) {
     wsConnectionCount++;
     console.log(`[STOMP Worker] ✅ WebSocket 연결 생성: 총 ${wsConnectionCount}회 (연결된 탭 수: ${connectedPorts.size})`);
 
-    let brokerURL = wsUrl;
-    if (wsUrl.startsWith("http")) {
-      brokerURL = wsUrl.replace(/^http/, "ws");
-    } else if (wsUrl === "/ws") {
+    let brokerURL = lastWsUrl;
+    if (lastWsUrl!.startsWith("http")) {
+      brokerURL = lastWsUrl!.replace(/^http/, "ws");
+    } else if (lastWsUrl === "/ws") {
       const protocol = self.location.protocol === "https:" ? "wss:" : "ws:";
       brokerURL = `${protocol}//${self.location.host}/ws`;
     }
@@ -106,6 +108,10 @@ self.onconnect = (e: MessageEvent) => {
 
     switch (data.type) {
       case "PING": {
+        if (!stompClient || !stompClient.active) {
+          console.log("[STOMP Worker] PING 수신 - 연결이 끊겨있어 재연결 시도합니다.");
+          checkConnectionRequired();
+        }
         break;
       }
       case "INIT": {


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #191

## 🧩 작업 내용
  변경한 내용:

  stompSharedWorker.ts
  - lastWsUrl 변수 추가 → 마지막으로 받은 wsUrl을 기억
  - checkConnectionRequired()에서 lastWsUrl 사용 → PING으로 호출해도 재연결 가능
  - PING 수신 시 연결이 끊겨있으면 자동 재연결

  stompClient.ts
  - visibilitychange 이벤트 추가 → 탭으로 돌아올 때 즉시 PING 전송

  동작 흐름:
  다른 탭 갔다가 이 탭으로 돌아옴
    → visibilitychange 감지 → 즉시 PING 전송
    → Worker: 연결 끊겼네 → 자동 재연결
    → 실시간 데이터 다시 들어옴

