### PR TITLE
[Fix] 자잘한 이슈들 수정

### DIFF
--- a/src/api/stockApi.ts
+++ b/src/api/stockApi.ts
@@ -353,6 +353,9 @@ export function useCancelOrderMutation(tickerCode: string) {
       queryClient.invalidateQueries({
         queryKey: stockQueryKeys.tradeHistory(tickerCode),
       });
+      queryClient.invalidateQueries({
+        queryKey: stockQueryKeys.cash,
+      });
     },
   });
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -67,7 +67,7 @@ const NAV_ITEMS: NavItemConfig[] = [
     id: "shinhan",
     label: "실전투자 바로가기",
     icon: Receipt,
-    href: "https://www.shinhansec.com/siw/customer-center/channel/channel_webTrading/contents.do",
+    href: "https://www.shinhansec.com/siw/customer-center/open-accounts/712501/view.do",
   },
 ];
 

--- a/src/components/onboarding/SpotlightTour.tsx
+++ b/src/components/onboarding/SpotlightTour.tsx
@@ -248,7 +248,7 @@ export default function SpotlightTour({
     if (!canReplay || hidden || isSidebarOpen) return null;
     return (
       <button
-        className="animate-float fixed top-16 right-4 lg:top-4 z-99 w-11 h-11 bg-white rounded-full shadow-lg flex items-center justify-center text-[#0046FF] hover:bg-gray-50 transition-colors"
+        className="animate-float fixed top-16 right-4 lg:top-4 z-99 w-11 h-11 bg-white dark:bg-[#1E3A8A] rounded-full shadow-lg flex items-center justify-center text-[#0046FF] dark:text-white hover:bg-gray-50 dark:hover:bg-[#1E40AF] transition-colors"
         onClick={handleReplay}
         title="가이드 다시보기"
       >

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -240,17 +240,14 @@ export default function LoginPage() {
               type="submit"
               variant={isFormValid ? "primary" : "invalid"}
               className={[
-                "w-full py-3 text-[16px] font-semibold mt-1",
+                "w-full py-3 text-[16px] font-semibold mt-1 flex items-center justify-center",
                 !isFormValid || isLoading
                   ? "cursor-not-allowed opacity-60"
                   : "",
               ].join(" ")}
             >
               {isLoading ? (
-                <span className="flex items-center justify-center gap-2">
-                  <Loader2 size={16} className="animate-spin" />
-                  잠시만요...
-                </span>
+                <Loader2 size={16} className="animate-spin" />
               ) : (
                 "로그인"
               )}

--- a/src/pages/stocks/[stockId]/StockDetailPage.tsx
+++ b/src/pages/stocks/[stockId]/StockDetailPage.tsx
@@ -212,12 +212,15 @@ export default function StockDetailPage() {
   }, [stockCode, queryClient, user?.userId]);
 
   useEffect(() => {
-    if (!quote) return;
-    const rate = quote.changeRate;
-    document.title = `${quote.currentPrice.toLocaleString()}원 ${rate > 0 ? "+" : ""}${rate.toFixed(2)}% | ${quote.stockName}`;
     return () => {
       document.title = "SOLMATE";
     };
+  }, []);
+
+  useEffect(() => {
+    if (!quote) return;
+    const rate = quote.changeRate;
+    document.title = `${quote.currentPrice.toLocaleString()}원 ${rate > 0 ? "+" : ""}${rate.toFixed(2)}% | ${quote.stockName}`;
   }, [quote]);
 
   useEffect(() => {

--- a/src/pages/user-list/userListPage.tsx
+++ b/src/pages/user-list/userListPage.tsx
@@ -51,11 +51,10 @@ import type { AccountSummaryData } from "@/api/accountSummaryApi";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type SortBy = "returnRate" | "returnAmount" | "follower";
+type SortBy = "returnRate" | "follower";
 
 const SORT_OPTIONS: { value: SortBy; label: string }[] = [
   { value: "returnRate", label: "수익률순" },
-  { value: "returnAmount", label: "수익순" },
   { value: "follower", label: "팔로워순" },
 ];
 
@@ -454,15 +453,9 @@ export default function UserListPage() {
     if (!allSummariesLoaded) return 0;
     const aData = summaryMap.get(a.userId)?.data;
     const bData = summaryMap.get(b.userId)?.data;
-    if (sortBy === "returnRate") {
-      return (
-        (bData?.totalReturnRate ?? -Infinity) -
-        (aData?.totalReturnRate ?? -Infinity)
-      );
-    }
     return (
-      (bData?.totalReturnAmount ?? -Infinity) -
-      (aData?.totalReturnAmount ?? -Infinity)
+      (bData?.totalReturnRate ?? -Infinity) -
+      (aData?.totalReturnRate ?? -Infinity)
     );
   });
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #198

## 💡 작업 배경
-  잠시만요 → 뺑글이로 바꾸기
-  파비콘 제목 계속 solmate로 중간에 반짝거림
-  실전투자 연결 url → 신투 모바일 계좌 증설로 → https://www.shinhansec.com/siw/customer-center/open-accounts/712501/view.do
-  다크모드에서 코치마크 버튼  → 어두운 파란색
-  수익률 수익순 둘중 하나 제거

## 🧩 작업 내용


## 📸 스크린샷(선택)


## 📝 기타