### PR TITLE
[Fix] 시장 지수 데이터 없을 때 카드 유지

### DIFF
--- a/src/api/homeApi.ts
+++ b/src/api/homeApi.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { fetchClient } from "@/lib/fetchClient";
 import type { ApiResponse } from "./authApi";
 
@@ -159,5 +159,7 @@ export function useMarketIndicesQuery() {
           throw err;
         }),
     staleTime: 60_000,
+    placeholderData: keepPreviousData,
+    gcTime: Infinity,
   });
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -239,9 +239,24 @@ function MarketIndicesRow({
   }
   return (
     <div className="flex gap-3">
-      {data.map((idx) => (
-        <MarketIndexCard key={idx.label} index={idx} />
-      ))}
+      {data.length === 0
+        ? ["KOSPI", "KOSDAQ", "USD/KRW"].map((label) => (
+            <div
+              key={label}
+              className="flex-1 min-w-0 bg-white dark:bg-slate-900 rounded-xl border border-gray-100 dark:border-slate-800 px-2 sm:px-4 py-3"
+            >
+              <p className="text-[10px] sm:text-[12px] text-gray-400 dark:text-slate-500 font-medium mb-1">
+                {label}
+              </p>
+              <p className="text-[14px] sm:text-[18px] font-semibold text-gray-400 dark:text-slate-600">
+                -
+              </p>
+              <p className="text-[10px] sm:text-[12px] text-gray-300 dark:text-slate-700 mt-0.5">
+                데이터 없음
+              </p>
+            </div>
+          ))
+        : data.map((idx) => <MarketIndexCard key={idx.label} index={idx} />)}
     </div>
   );
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #198 

## 💡 작업 배경
홈페이지 시장 지수(코스피/코스닥/환율) 영역에서 API 호출 실패 또는 백엔드가 null을 반환할 경우, 카드가 통째로 사라지는 문제가 있었음

## 🧩 작업 내용
  src/api/homeApi.ts
  - keepPreviousData 옵션 추가 → API 재fetch 실패 시 이전 캐시 데이터 유지
  - gcTime: Infinity 추가 → 탭 전환 등으로 캐시가 사라지지 않도록 영구 보존

  src/pages/HomePage.tsx
  - MarketIndicesRow 컴포넌트에 fallback UI 추가 → 데이터가 없을 경우 KOSPI / KOSDAQ / USD/KRW 카드 틀을 유지하고 - / 데이터 없음 으로 표시    
          

## 📸 스크린샷(선택)


## 📝 기타