### PR TITLE
[Fix] 알림 수 오류 수정

### DIFF
--- a/src/api/notificationApi.ts
+++ b/src/api/notificationApi.ts
@@ -99,10 +99,30 @@ export function useNotificationSubscription(userId: number | undefined) {
       const item: NotificationItem = JSON.parse(message.body);
 
       if (item.eventType === "DELETE") {
+        const prevList = queryClient.getQueryData<NotificationItem[]>(notificationQueryKeys.list);
+        const deletedItem = prevList?.find((n) => n.notificationId === item.notificationId);
+
         queryClient.setQueryData<NotificationItem[]>(
           notificationQueryKeys.list,
           (prev) => prev ? prev.filter((n) => n.notificationId !== item.notificationId) : prev,
         );
+
+        if (deletedItem && !deletedItem.isRead) {
+          queryClient.setQueryData<NotificationCountResponse>(
+            notificationQueryKeys.unreadCount,
+            (prev) => {
+              if (!prev) return prev;
+              const categoryKey = deletedItem.category.toLowerCase() as keyof Omit<NotificationCountResponse, "total">;
+              return {
+                ...prev,
+                total: Math.max(0, prev.total - 1),
+                [categoryKey]: Math.max(0, prev[categoryKey] - 1),
+              };
+            },
+          );
+        } else {
+          queryClient.invalidateQueries({ queryKey: notificationQueryKeys.unreadCount });
+        }
         return;
       }
 

--- a/src/pages/mentor/MyMentorPage.tsx
+++ b/src/pages/mentor/MyMentorPage.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/api/mentorApi";
 import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
 import { cancelMentoring } from "@/api/userListApi";
+import { notificationQueryKeys } from "@/api/notificationApi";
 import { useQueryClient } from "@tanstack/react-query";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -222,6 +223,7 @@ export default function MyMentorPage() {
             try {
               await cancelMentoring(mentorId);
               await queryClient.invalidateQueries({ queryKey: ["mentor"] });
+              queryClient.invalidateQueries({ queryKey: notificationQueryKeys.unreadCount });
               showToast("멘토 취소가 완료되었습니다.");
             } catch {
               showToast("멘토 취소에 실패했습니다. 다시 시도해주세요.");

--- a/src/pages/users/UserProfilePage.tsx
+++ b/src/pages/users/UserProfilePage.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/api/mentorApi";
 import { useAccountSummaryByUserQuery } from "@/api/accountSummaryApi";
 import { followUser, unfollowUser, requestMentoring, cancelMentoring, cancelPendingMentoring } from "@/api/userListApi";
+import { notificationQueryKeys } from "@/api/notificationApi";
 import Button from "@/components/ui/Button";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -99,6 +100,7 @@ export default function UserProfilePage() {
       await cancelMentoring(id);
       queryClient.invalidateQueries({ queryKey: ["users", id] });
       queryClient.invalidateQueries({ queryKey: ["mentor"] });
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.unreadCount });
       setShowCancelModal(false);
     } catch {
       // 실패 시 무시
@@ -110,6 +112,7 @@ export default function UserProfilePage() {
       await cancelPendingMentoring(id);
       queryClient.invalidateQueries({ queryKey: ["users", id] });
       queryClient.invalidateQueries({ queryKey: ["mentor"] });
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.unreadCount });
       setShowPendingCancelModal(false);
     } catch {
       // 실패 시 무시


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #201 

## 💡 작업 배경
멘토 신청 후 취소 시 알림 수가 바로 업데이트 되지않음

## 🧩 작업 내용
fix #1: item.isRead는 백엔드가 WebSocket 페이로드에 보내는 값인데, 실제 프론트 캐시의 isRead 상태와 다를 수 있음
fix #2: invalidateQueries는 서버에 재요청을 보내는 async 작업인데, 취소 직후 서버가 카운트를 즉시 업데이트하지 않으면 여전히 이전 값이 반환됨 → 새로고침 시점엔 서버가 업데이트 완료되어 올바른 값 반환

1. getQueryData로 삭제 전 캐시에서 해당 알림을 직접 조회
2. 실제 캐시의 isRead 값으로 판단
3. setQueryData로 동기적으로 즉시 카운트 감소

## 📸 스크린샷(선택)


## 📝 기타