### PR TITLE
[Fix] 멘토 멘티 내 매매일지 차트 추가

### DIFF
--- a/src/components/profile/MenteeTradeDiaryTab.tsx
+++ b/src/components/profile/MenteeTradeDiaryTab.tsx
@@ -13,6 +13,7 @@ import {
   useDeleteCommentMutation,
 } from "@/api/tradeDiaryApi";
 import { useStocksQuery } from "@/api/stockApi";
+import DiaryMiniChart from "@/components/profile/DiaryMiniChart";
 
 type Props = {
   items: MyDiariesItem[];
@@ -172,6 +173,16 @@ function DiaryDetail({
             </div>
           ))}
         </div>
+
+        {detail.tickerCode && (
+          <DiaryMiniChart
+            tickerCode={detail.tickerCode}
+            tradeDate={detail.createdAt.slice(0, 10)}
+            tradeDateTime={detail.createdAt}
+            tradeType={detail.tradeType}
+            filledPrice={detail.filledPrice}
+          />
+        )}
 
         {/* 매매 일지 본문 */}
         <div className="pt-2">

--- a/src/components/profile/MentorTradeDiaryTab.tsx
+++ b/src/components/profile/MentorTradeDiaryTab.tsx
@@ -13,6 +13,7 @@ import {
   useDeleteCommentMutation,
 } from "@/api/tradeDiaryApi";
 import { useStocksQuery } from "@/api/stockApi";
+import DiaryMiniChart from "@/components/profile/DiaryMiniChart";
 
 type Props = {
   items: MyDiariesItem[];
@@ -169,6 +170,16 @@ function DiaryDetail({
             </div>
           ))}
         </div>
+
+        {detail.tickerCode && (
+          <DiaryMiniChart
+            tickerCode={detail.tickerCode}
+            tradeDate={detail.createdAt.slice(0, 10)}
+            tradeDateTime={detail.createdAt}
+            tradeType={detail.tradeType}
+            filledPrice={detail.filledPrice}
+          />
+        )}
 
         <div>
           <p className="text-[12px] text-gray-400 dark:text-slate-500 mb-2">

--- a/src/components/profile/TradeDiaryTab.tsx
+++ b/src/components/profile/TradeDiaryTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Search } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import Badge from "@/components/ui/Badge";
 import Avatar from "@/components/ui/Avatar";
 import type { MyDiariesItem } from "@/api/tradeDiaryApi";
@@ -7,6 +8,7 @@ import { useStocksQuery } from "@/api/stockApi";
 
 type Props = {
   items: MyDiariesItem[];
+  navigable?: boolean;
 };
 
 function formatDate(createdAt: string) {
@@ -38,7 +40,8 @@ function groupByDate(items: MyDiariesItem[]) {
   return Array.from(map.entries());
 }
 
-export default function TradeDiaryTab({ items }: Props) {
+export default function TradeDiaryTab({ items, navigable = true }: Props) {
+  const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const { data: stocks = [] } = useStocksQuery();
   const logoMap = new Map(stocks.map((s) => [s.stockName, s.stockLogo]));
@@ -84,7 +87,8 @@ export default function TradeDiaryTab({ items }: Props) {
                   return (
                     <div
                       key={item.diaryId}
-                      className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-4 px-5 py-4"
+                      onClick={navigable ? () => navigate(`/trade-diary/${item.diaryId}`) : undefined}
+                      className={`flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-4 px-5 py-4 transition-colors ${navigable ? "cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-800" : ""}`}
                     >
                       {/* 좌측: 종목 정보 */}
                       <div className="flex items-center gap-3 sm:w-52 sm:shrink-0">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -396,16 +396,16 @@ function HoldingsTable({
                 <th className="text-left px-5 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium">
                   종목
                 </th>
-                <th className="text-right px-4 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium min-w-14">
+                <th className="text-right px-4 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium min-w-14 whitespace-nowrap">
                   보유량
                 </th>
-                <th className="text-right px-4 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium min-w-25">
+                <th className="text-right px-4 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium min-w-25 whitespace-nowrap">
                   평가금액
                 </th>
-                <th className="text-right px-4 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium min-w-25">
+                <th className="text-right px-4 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium min-w-25 whitespace-nowrap">
                   평가손익
                 </th>
-                <th className="text-right px-5 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium min-w-20">
+                <th className="text-right px-5 py-2.5 text-[12px] text-gray-400 dark:text-slate-500 font-medium min-w-20 whitespace-nowrap">
                   수익률
                 </th>
               </tr>
@@ -444,12 +444,12 @@ function HoldingsTable({
                     </td>
 
                     {/* 2. 보유량 (모바일: 숨김 / 데스크탑: 2열) */}
-                    <td className="hidden sm:table-cell px-4 py-3 text-right text-[14px] text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                    <td className="hidden sm:table-cell px-4 py-3 text-right text-[14px] text-gray-600 dark:text-gray-400 whitespace-nowrap tabular-nums">
                       {stock.quantity}주
                     </td>
 
                     {/* 3. 평가금액 (모바일: 좌측 하단 / 데스크탑: 3열) */}
-                    <td className="px-5 pb-5 sm:p-0 sm:px-4 sm:py-3 sm:table-cell sm:text-right whitespace-nowrap">
+                    <td className="px-5 pb-5 sm:p-0 sm:px-4 sm:py-3 sm:table-cell sm:text-right whitespace-nowrap tabular-nums">
                       <div className="flex flex-col sm:block">
                         <span className="sm:hidden text-[11px] text-gray-400 mb-0.5">
                           평가금액
@@ -461,7 +461,7 @@ function HoldingsTable({
                     </td>
 
                     {/* 4. 평가손익 (모바일: 우측 하단 고정 / 데스크탑: 4열) */}
-                    <td className="absolute right-5 bottom-4 sm:static sm:table-cell sm:px-4 sm:py-3 sm:text-right whitespace-nowrap">
+                    <td className="absolute right-5 bottom-4 sm:static sm:table-cell sm:px-4 sm:py-3 sm:text-right whitespace-nowrap tabular-nums">
                       <div className="flex flex-col items-end sm:block">
                         {/* 모바일에서는 여기서 수익률(%)도 같이 보여줌 */}
                         <div className="sm:hidden mb-0.5">
@@ -480,7 +480,7 @@ function HoldingsTable({
                     </td>
 
                     {/* 5. 수익률 (모바일: 숨김 (4번에서 처리) / 데스크탑: 5열) */}
-                    <td className="hidden sm:table-cell px-5 py-3 text-right whitespace-nowrap">
+                    <td className="hidden sm:table-cell px-5 py-3 text-right whitespace-nowrap tabular-nums">
                       <ReturnText
                         value={`${isPositive ? "+" : ""}${stock.returnRate.toFixed(2)}%`}
                         isPositive={isPositive}

--- a/src/pages/users/UserProfilePage.tsx
+++ b/src/pages/users/UserProfilePage.tsx
@@ -269,10 +269,10 @@ export default function UserProfilePage() {
             />
           </div>
           <div className={`p-5 flex-1 md:min-h-0 ${activeTab === "portfolio" ? "md:overflow-hidden overflow-y-auto" : "overflow-y-auto"}`}>
-            {activeTab === "diary" && <TradeDiaryTab items={diaries} />}
+            {activeTab === "diary" && <TradeDiaryTab items={diaries} navigable={isMentor || isMentee} />}
             {activeTab === "history" && <TradeHistoryTab items={tradeHistories} />}
             {/* 모바일에서 activeTab이 portfolio인 경우 diary 콘텐츠로 폴백 */}
-            {activeTab === "portfolio" && <div className="md:hidden"><TradeDiaryTab items={diaries} /></div>}
+            {activeTab === "portfolio" && <div className="md:hidden"><TradeDiaryTab items={diaries} navigable={isMentor || isMentee} /></div>}
             {activeTab === "portfolio" && (
               <div className="hidden md:block h-full">
                 <PortfolioTab


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #196

## 💡 작업 배경
- 멘토 멘티 내 매매일지 차트 추가
## 🧩 작업 내용
- 멘토 멘티 내 매매일지 차트 추가

## 📸 스크린샷(선택)
<img width="993" height="878" alt="image" src="https://github.com/user-attachments/assets/46cde887-5ef9-4686-ab56-9ce9c8715394" />


## 📝 기타